### PR TITLE
feat(pr-shepherd): robust CI-wait + optional webhook mode

### DIFF
--- a/skills/pr-shepherd/SKILL.md
+++ b/skills/pr-shepherd/SKILL.md
@@ -52,11 +52,18 @@ runaway loop that keeps pushing commits is worse than asking.
 2. **Branch on the verdict:**
    - `NOT_ELIGIBLE` — draft or closed. Report and stop.
    - `WAITING_CI` — checks are still QUEUED/IN_PROGRESS or mergeability is still
-     computing. Wait, don't poll-spin. Block on completion, then re-read:
+     computing. Wait, don't poll-spin:
      ```bash
-     gh pr checks <PR> --watch --fail-fast=false   # returns when all checks settle
+     scripts/wait_for_settle.sh <PR>   # blocks until the verdict leaves WAITING_CI
      ```
-     Then go back to step 1.
+     It blocks on `gh pr checks --watch` while checks are the holdup, and short-
+     polls the gate otherwise — so it wakes not only on CI settling but on
+     mergeability finishing and review/thread changes mid-wait (which `--watch`
+     alone cannot see), avoiding the spin where `WAITING_CI` is driven by
+     mergeability still computing. It prints the same JSON the next read would, so
+     treat its output as your step-1 read for this iteration and branch on the new
+     verdict. On `--max-wait` timeout it exits `10` with a resume hint — re-run it
+     to continue waiting.
    - `NEEDS_WORK` — address the specific `blockers[]` (next section), push, and
      loop.
    - `BLOCKED_HUMAN` — something only a person can clear (a required approval, an
@@ -181,5 +188,11 @@ Re-confirm GREEN immediately before merging — state can change between iterati
 - **Long-lived branch keep-list**: extra patterns beyond the built-in set.
 - **Iteration cap**: default 5.
 - **Flake re-run policy**: default one re-run per failing check, then escalate.
+- **Wait tuning**: `wait_for_settle.sh --interval` (default 10s) and `--max-wait`
+  (default 1800s, resumable on timeout).
 - **Required-only checks**: by default _all_ checks must pass (the user's strict
   definition); optionally relax to "only branch-protection-required checks".
+- **Wait transport**: polling/`--watch` by default. For repo-admin users on a
+  local host who want push-latency wakes on review/branch events, an optional
+  webhook mode is documented in `references/github-api.md` §11 — it is a wake
+  signal only; `pr_status.sh` stays the gate.

--- a/skills/pr-shepherd/references/github-api.md
+++ b/skills/pr-shepherd/references/github-api.md
@@ -192,7 +192,9 @@ gh extension install cli/gh-webhook
 gh webhook forward --repo=OWNER/REPO \
   --events=check_run,check_suite,status,pull_request_review,pull_request_review_thread,workflow_run \
   --url=http://localhost:PORT/hook    # point at a minimal local receiver
-# org-scoped events additionally need: gh auth refresh -s admin:org_hook
+# repo-level events (above) need no extra scope. ONLY org-scoped events need
+# `gh auth refresh -s admin:org_hook`, which persistently broadens your gh token
+# to manage every webhook in the org — see the scope caveat below before running.
 ```
 
 **Integration stance — webhook is a wake signal, never the gate.** On each
@@ -207,5 +209,9 @@ re-querying the PR — the webhook just tells you _when_ to look.
 - A **long-running foreground daemon**; **one forwarder per repo** (a second
   start fails with `Hook already exists`).
 - Officially **dev/test only**, and **not supported on GitHub Enterprise Server**.
+- `admin:org_hook` (org-scoped events only) **persistently expands your `gh`
+  token** to manage every webhook in the org — a broad, lasting grant for a
+  convenience wake signal. Skip it unless you genuinely need org-level events;
+  repo-level events need no extra scope.
 - Keep the committed skill free of any real URL, port, token, or local path — use
   placeholders (`OWNER/REPO`, `PORT`) as above; this is a public repository.

--- a/skills/pr-shepherd/references/github-api.md
+++ b/skills/pr-shepherd/references/github-api.md
@@ -20,6 +20,7 @@ the repo owner, repo name, and PR number.
 8. Merge + remote branch deletion
 9. Local cleanup (worktree, branch, main)
 10. State-value cheat sheet
+11. Optional: webhook-driven waiting (advanced — repo admin + local host)
 
 ---
 
@@ -166,3 +167,45 @@ verdict that the PR merged, so the force delete is safe.
   non-required checks pending/failing), DRAFT, HAS_HOOKS, UNKNOWN.
 - **PR.reviewDecision**: APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or null
   (no review required by branch protection).
+
+## 11. Optional: webhook-driven waiting (advanced — repo admin + local host)
+
+The default wait (`scripts/wait_for_settle.sh`, §1) polls and needs only an
+authenticated `gh`. If you want **push-latency wakes** on review/branch events —
+not just CI — and you can satisfy all three conditions below, you can have GitHub
+forward webhooks to you instead. Most of the time the default is the better
+choice; reach for this only when:
+
+1. you have **repo admin** (required to create the hook — there is no
+   non-admin path), **and**
+2. you run on a **local host that can hold a long-running foreground process**
+   (this collides with the "purely API/MCP surface" mode in SKILL.md), **and**
+3. you specifically want sub-second wakes on `pull_request_review` /
+   `pull_request_review_thread` / branch updates, which `gh pr checks --watch`
+   never sees.
+
+The official `cli/gh-webhook` extension tunnels deliveries through GitHub's own
+forwarding service, so **no public endpoint, smee, or ngrok is needed**:
+
+```bash
+gh extension install cli/gh-webhook
+gh webhook forward --repo=OWNER/REPO \
+  --events=check_run,check_suite,status,pull_request_review,pull_request_review_thread,workflow_run \
+  --url=http://localhost:PORT/hook    # point at a minimal local receiver
+# org-scoped events additionally need: gh auth refresh -s admin:org_hook
+```
+
+**Integration stance — webhook is a wake signal, never the gate.** On each
+relevant delivery, re-run `scripts/pr_status.sh` and branch on its verdict exactly
+as the polling loop does. There is **no `mergeable` webhook event** (GitHub
+computes mergeability asynchronously), so the merge gate can only come from
+re-querying the PR — the webhook just tells you _when_ to look.
+
+**Caveats, stated plainly:**
+
+- Requires **repo admin**; frequently unavailable on shared/org repos.
+- A **long-running foreground daemon**; **one forwarder per repo** (a second
+  start fails with `Hook already exists`).
+- Officially **dev/test only**, and **not supported on GitHub Enterprise Server**.
+- Keep the committed skill free of any real URL, port, token, or local path — use
+  placeholders (`OWNER/REPO`, `PORT`) as above; this is a public repository.

--- a/skills/pr-shepherd/scripts/wait_for_settle.sh
+++ b/skills/pr-shepherd/scripts/wait_for_settle.sh
@@ -20,9 +20,10 @@
 #   wait_for_settle.sh --interval 10 --max-wait 1800 <pr-number>
 #
 # Requires: gh (authenticated), jq, bash. No new hard dependency over
-# pr_status.sh; uses `timeout`/`gtimeout` if present to bound each gate read and
-# the checks-watch (so a hung gh call retries and --max-wait is honored),
-# falling back to unbounded calls otherwise.
+# pr_status.sh. With `timeout`/`gtimeout` present it bounds each gate read and
+# blocks efficiently on the checks-watch; without it, the checks-wait falls back
+# to interval polling so --max-wait is honored on every platform (only the
+# best-effort gate-read timeout is lost).
 # Output: the settled verdict JSON on stdout (same shape pr_status.sh emits).
 # Exit code mirrors the settled verdict (0 GREEN / 20 NEEDS_WORK / 30
 # BLOCKED_HUMAN / 40 NOT_ELIGIBLE / 50 ERROR). Exit 10 only on --max-wait
@@ -143,23 +144,26 @@ while true; do
     repo="$(printf '%s' "$json" | jq -r '.repo // empty' 2>/dev/null || true)"
   fi
 
-  if [ "$pending" -gt 0 ] && [ -n "$pr" ]; then
-    # checks are the holdup: block until they settle (no polling churn). the
-    # gate, not --watch, decides green, so ignore --watch's own exit code.
-    # --repo pins the watch to the repo pr_status.sh queried (not the cwd repo),
-    # so the owner/repo and url arg forms watch the right PR. wrap in timeout so
-    # --max-wait is honored even if CI hangs; unbounded if no timeout binary.
-    watch=(gh pr checks "$pr" --watch --fail-fast=false --interval "$INTERVAL")
-    [ -n "$repo" ] && watch+=(--repo "$repo")
+  if [ "$pending" -gt 0 ] && [ -n "$pr" ] && [ -n "$TIMEOUT_BIN" ]; then
+    # checks are the holdup AND we can bound the watch: block on it (efficient,
+    # no polling churn). the gate, not --watch, decides green, so ignore its exit
+    # code. --repo pins the watch to the repo pr_status.sh queried (not the cwd
+    # repo), so the owner/repo and url arg forms watch the right PR. the timeout
+    # wrap keeps --max-wait honored even if CI hangs. (without a timeout binary
+    # we fall through to the polling branch below instead — never an unbounded
+    # watch, so --max-wait holds on every platform.)
     remaining=$((MAX_WAIT - SECONDS)); [ "$remaining" -lt 1 ] && remaining=1
-    [ -n "$TIMEOUT_BIN" ] && watch=("$TIMEOUT_BIN" "$remaining" "${watch[@]}")
+    watch=("$TIMEOUT_BIN" "$remaining" gh pr checks "$pr" --watch --fail-fast=false --interval "$INTERVAL")
+    [ -n "$repo" ] && watch+=(--repo "$repo")
     t0=$SECONDS
     "${watch[@]}" >/dev/null 2>&1 || true
     # guard against a fast-returning/erroring --watch spinning the loop hot
     [ $((SECONDS - t0)) -lt "$INTERVAL" ] && [ "$SECONDS" -lt "$MAX_WAIT" ] && sleep "$INTERVAL"
   else
-    # mergeability still computing, waiting on a review/thread, or backing off a
-    # transient error — none of which --watch can see. short, bounded poll.
+    # interval-poll the gate: nothing pending (mergeability/review wait, which
+    # --watch can't see), no timeout binary to bound a --watch, or backing off a
+    # transient error. re-reading the full verdict keeps --max-wait honored via
+    # the top-of-loop cap, so this stays bounded and resumable on every platform.
     sleep "$INTERVAL"
   fi
 done

--- a/skills/pr-shepherd/scripts/wait_for_settle.sh
+++ b/skills/pr-shepherd/scripts/wait_for_settle.sh
@@ -20,10 +20,10 @@
 #   wait_for_settle.sh --interval 10 --max-wait 1800 <pr-number>
 #
 # Requires: gh (authenticated), jq, bash. No new hard dependency over
-# pr_status.sh. With `timeout`/`gtimeout` present it bounds each gate read and
-# blocks efficiently on the checks-watch; without it, the checks-wait falls back
-# to interval polling so --max-wait is honored on every platform (only the
-# best-effort gate-read timeout is lost).
+# pr_status.sh. `timeout`/`gtimeout` is used if present to bound reads and block
+# efficiently on the checks-watch; without it, reads are bounded by a background
+# watchdog and the checks-wait falls back to interval polling — so --max-wait is
+# honored on every platform.
 # Output: the settled verdict JSON on stdout (same shape pr_status.sh emits).
 # Exit code mirrors the settled verdict (0 GREEN / 20 NEEDS_WORK / 30
 # BLOCKED_HUMAN / 40 NOT_ELIGIBLE / 50 ERROR). Exit 10 only on --max-wait
@@ -76,18 +76,41 @@ STATUS="$SCRIPT_DIR/pr_status.sh"
 [ -x "$STATUS" ] || { echo "wait_for_settle: cannot run $STATUS" >&2; exit 50; }
 
 # Resolve a timeout binary once (GNU coreutils `timeout`, or `gtimeout` on
-# macOS/Homebrew). With it, each gate read is bounded and the checks-watch is
-# blocked efficiently. Without it, reads run unbounded (best-effort) and the
-# checks-wait falls back to interval polling — never an unbounded watch.
+# macOS/Homebrew). It is preferred but not required: with it, each gate read is
+# bounded and the checks-watch is blocked efficiently; without it, reads are
+# bounded by a background+watchdog fallback (see read_gate) and the checks-wait
+# falls back to interval polling — never an unbounded watch or read.
 TIMEOUT_BIN=""
 if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
 elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout; fi
 
-# read the gate, bounding it by READ_TIMEOUT so a hung gh call surfaces as
-# exit 124 (treated as a transient, retryable error) instead of blocking forever.
+# Read the gate, bounding it by READ_TIMEOUT so a hung gh call surfaces as exit
+# 124 (treated as a transient, retryable error) instead of blocking --max-wait
+# forever. With a timeout binary that bound is one exec; without one, a
+# background job + watchdog kill enforces it portably — so the resumable
+# --max-wait promise holds on every platform, not just where `timeout` exists.
 read_gate() {
-  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$READ_TIMEOUT" "$STATUS" "$@"
-  else "$STATUS" "$@"; fi
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$READ_TIMEOUT" "$STATUS" "$@"
+    return $?
+  fi
+  local out waited=0 pid rc
+  out="$(mktemp "${TMPDIR:-/tmp}/wfs.XXXXXX")" || return 50
+  "$STATUS" "$@" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$READ_TIMEOUT" ]; then
+      pkill -P "$pid" 2>/dev/null || true   # reap the hung child (e.g. gh) first
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      cat "$out"; rm -f "$out"
+      return 124
+    fi
+    sleep 1; waited=$((waited + 1))
+  done
+  wait "$pid"; rc=$?
+  cat "$out"; rm -f "$out"
+  return "$rc"
 }
 
 SECONDS=0

--- a/skills/pr-shepherd/scripts/wait_for_settle.sh
+++ b/skills/pr-shepherd/scripts/wait_for_settle.sh
@@ -65,13 +65,20 @@ while [ $# -gt 0 ]; do
 done
 [ "${#ARGS[@]}" -gt 0 ] || usage 1
 
+# --interval / --max-wait flow into $((...)) and sleep, so reject non-integers
+# up front with a clear message instead of a later arithmetic-expansion crash.
+case "$INTERVAL" in ''|*[!0-9]*) echo "wait_for_settle: --interval must be a non-negative integer (got '$INTERVAL')" >&2; exit 50 ;; esac
+case "$MAX_WAIT" in ''|*[!0-9]*) echo "wait_for_settle: --max-wait must be a non-negative integer (got '$MAX_WAIT')" >&2; exit 50 ;; esac
+[ "$INTERVAL" -ge 1 ] || { echo "wait_for_settle: --interval must be >= 1" >&2; exit 50; }
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUS="$SCRIPT_DIR/pr_status.sh"
 [ -x "$STATUS" ] || { echo "wait_for_settle: cannot run $STATUS" >&2; exit 50; }
 
 # Resolve a timeout binary once (GNU coreutils `timeout`, or `gtimeout` on
-# macOS/Homebrew). Used to bound both the gate read and the checks-watch. If
-# neither exists, both run unbounded — the documented graceful fallback.
+# macOS/Homebrew). With it, each gate read is bounded and the checks-watch is
+# blocked efficiently. Without it, reads run unbounded (best-effort) and the
+# checks-wait falls back to interval polling — never an unbounded watch.
 TIMEOUT_BIN=""
 if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
 elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout; fi
@@ -130,7 +137,9 @@ while true; do
   # a long wait stays resumable rather than running unbounded.
   if [ "$SECONDS" -ge "$MAX_WAIT" ]; then
     [ -n "$last_json" ] && printf '%s\n' "$last_json"
-    echo "wait_for_settle: still WAITING_CI after ${MAX_WAIT}s. Re-run to resume: $(basename "$0") ${ARGS[*]}" >&2
+    # include the effective knobs so resuming keeps custom --interval/--max-wait
+    # (ARGS holds only the positional pr args; the flags were parsed out).
+    echo "wait_for_settle: still WAITING_CI after ${MAX_WAIT}s. Re-run to resume: $(basename "$0") --interval $INTERVAL --max-wait $MAX_WAIT ${ARGS[*]}" >&2
     exit 10
   fi
 

--- a/skills/pr-shepherd/scripts/wait_for_settle.sh
+++ b/skills/pr-shepherd/scripts/wait_for_settle.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# wait_for_settle.sh — block until pr_status.sh's verdict *leaves* WAITING_CI,
+# then print that settled verdict JSON and exit with its code.
+#
+# Why this exists: `pr_status.sh` reports WAITING_CI when EITHER checks are still
+# pending OR mergeability is still UNKNOWN. The old wait (`gh pr checks --watch`)
+# only handles the first case — when WAITING_CI is driven by mergeability still
+# computing (no pending checks), `--watch` returns immediately and the caller
+# re-reads, re-gets WAITING_CI, and spins. `--watch` is also blind to review /
+# thread state changing mid-wait. This wrapper closes that gap:
+#   - checks pending  -> block on `gh pr checks --watch` (efficient, no polling)
+#   - otherwise       -> short, bounded poll of the full gate (catches
+#                        mergeability finishing AND review/thread changes)
+# It never invents a verdict; pr_status.sh stays the single source of truth.
+#
+# Usage (same arg forms as pr_status.sh, plus two knobs):
+#   wait_for_settle.sh <pr-number>
+#   wait_for_settle.sh <owner/repo> <pr-number>
+#   wait_for_settle.sh <pr-url>
+#   wait_for_settle.sh --interval 10 --max-wait 1800 <pr-number>
+#
+# Requires: gh (authenticated), jq, bash. No new hard dependency over
+# pr_status.sh; uses `timeout`/`gtimeout` if present to bound each gate read and
+# the checks-watch (so a hung gh call retries and --max-wait is honored),
+# falling back to unbounded calls otherwise.
+# Output: the settled verdict JSON on stdout (same shape pr_status.sh emits).
+# Exit code mirrors the settled verdict (0 GREEN / 20 NEEDS_WORK / 30
+# BLOCKED_HUMAN / 40 NOT_ELIGIBLE / 50 ERROR). Exit 10 only on --max-wait
+# timeout while still WAITING_CI — re-run to resume the wait.
+set -euo pipefail
+
+INTERVAL=10      # seconds between polls / --watch refresh interval
+MAX_WAIT=1800    # cap on total wall-clock wait; resumable on timeout
+READ_TIMEOUT=60  # cap on a single gate read, so a hung gh/GraphQL call retries
+
+usage() {
+  cat >&2 <<'EOF'
+wait_for_settle.sh — block until pr_status.sh's verdict leaves WAITING_CI, then
+print that settled verdict JSON and exit with its code.
+
+Usage (same arg forms as pr_status.sh, plus two knobs):
+  wait_for_settle.sh <pr-number>
+  wait_for_settle.sh <owner/repo> <pr-number>
+  wait_for_settle.sh <pr-url>
+  wait_for_settle.sh [--interval SECONDS] [--max-wait SECONDS] <pr...>
+
+Defaults: --interval 10, --max-wait 1800. Exit code mirrors the settled verdict
+(0/20/30/40/50); exit 10 only on --max-wait timeout (re-run to resume).
+EOF
+  exit "${1:-0}"
+}
+
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval) INTERVAL="${2:?--interval needs a value}"; shift 2 ;;
+    --interval=*) INTERVAL="${1#*=}"; shift ;;
+    --max-wait) MAX_WAIT="${2:?--max-wait needs a value}"; shift 2 ;;
+    --max-wait=*) MAX_WAIT="${1#*=}"; shift ;;
+    -h|--help) usage 0 ;;
+    --) shift; while [ $# -gt 0 ]; do ARGS+=("$1"); shift; done ;;
+    *) ARGS+=("$1"); shift ;;
+  esac
+done
+[ "${#ARGS[@]}" -gt 0 ] || usage 1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS="$SCRIPT_DIR/pr_status.sh"
+[ -x "$STATUS" ] || { echo "wait_for_settle: cannot run $STATUS" >&2; exit 50; }
+
+# Resolve a timeout binary once (GNU coreutils `timeout`, or `gtimeout` on
+# macOS/Homebrew). Used to bound both the gate read and the checks-watch. If
+# neither exists, both run unbounded — the documented graceful fallback.
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout; fi
+
+# read the gate, bounding it by READ_TIMEOUT so a hung gh call surfaces as
+# exit 124 (treated as a transient, retryable error) instead of blocking forever.
+read_gate() {
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$READ_TIMEOUT" "$STATUS" "$@"
+  else "$STATUS" "$@"; fi
+}
+
+SECONDS=0
+seen_ok=0
+errors=0
+last_json=""
+
+while true; do
+  set +e
+  json="$(read_gate "${ARGS[@]}")"
+  code=$?
+  set -e
+  [ -n "$json" ] && last_json="$json"
+
+  if [ "$code" = 124 ]; then
+    # gate read hit READ_TIMEOUT (gh/GraphQL hung) — always transient, even on
+    # the first read. back off and retry; give up only after several in a row.
+    errors=$((errors + 1))
+    if [ "$errors" -ge 5 ]; then
+      echo "wait_for_settle: gate read timed out ${errors}x in a row (gh/GraphQL hung); giving up." >&2
+      exit 50
+    fi
+  elif [ "$code" = 50 ]; then
+    if [ "$seen_ok" != 1 ]; then
+      # first read failed: almost always a usage / access error, not a blip.
+      # don't spend the retry budget on it — surface and exit.
+      [ -n "$json" ] && printf '%s\n' "$json"
+      exit 50
+    fi
+    errors=$((errors + 1))
+    if [ "$errors" -ge 5 ]; then
+      [ -n "$json" ] && printf '%s\n' "$json"
+      echo "wait_for_settle: pr_status.sh failed ${errors}x in a row; giving up." >&2
+      exit 50
+    fi
+  elif [ "$code" != 10 ]; then
+    # settled verdict (GREEN / NEEDS_WORK / BLOCKED_HUMAN / NOT_ELIGIBLE):
+    # emit it as a valid gate read and mirror the exit code.
+    printf '%s\n' "$json"
+    exit "$code"
+  else
+    seen_ok=1
+    errors=0
+  fi
+
+  # still WAITING_CI (or backing off a transient error). honor the cap first so
+  # a long wait stays resumable rather than running unbounded.
+  if [ "$SECONDS" -ge "$MAX_WAIT" ]; then
+    [ -n "$last_json" ] && printf '%s\n' "$last_json"
+    echo "wait_for_settle: still WAITING_CI after ${MAX_WAIT}s. Re-run to resume: $(basename "$0") ${ARGS[*]}" >&2
+    exit 10
+  fi
+
+  pending=0
+  pr=""
+  repo=""
+  if [ "$code" = 10 ] && [ -n "$json" ]; then
+    pending="$(printf '%s' "$json" | jq -r '.checks.pending // 0' 2>/dev/null || echo 0)"
+    pending="${pending//[^0-9]/}"; pending="${pending:-0}"
+    pr="$(printf '%s' "$json" | jq -r '.pr // empty' 2>/dev/null || true)"
+    repo="$(printf '%s' "$json" | jq -r '.repo // empty' 2>/dev/null || true)"
+  fi
+
+  if [ "$pending" -gt 0 ] && [ -n "$pr" ]; then
+    # checks are the holdup: block until they settle (no polling churn). the
+    # gate, not --watch, decides green, so ignore --watch's own exit code.
+    # --repo pins the watch to the repo pr_status.sh queried (not the cwd repo),
+    # so the owner/repo and url arg forms watch the right PR. wrap in timeout so
+    # --max-wait is honored even if CI hangs; unbounded if no timeout binary.
+    watch=(gh pr checks "$pr" --watch --fail-fast=false --interval "$INTERVAL")
+    [ -n "$repo" ] && watch+=(--repo "$repo")
+    remaining=$((MAX_WAIT - SECONDS)); [ "$remaining" -lt 1 ] && remaining=1
+    [ -n "$TIMEOUT_BIN" ] && watch=("$TIMEOUT_BIN" "$remaining" "${watch[@]}")
+    t0=$SECONDS
+    "${watch[@]}" >/dev/null 2>&1 || true
+    # guard against a fast-returning/erroring --watch spinning the loop hot
+    [ $((SECONDS - t0)) -lt "$INTERVAL" ] && [ "$SECONDS" -lt "$MAX_WAIT" ] && sleep "$INTERVAL"
+  else
+    # mergeability still computing, waiting on a review/thread, or backing off a
+    # transient error — none of which --watch can see. short, bounded poll.
+    sleep "$INTERVAL"
+  fi
+done

--- a/skills/pr-shepherd/scripts/wait_for_settle.sh
+++ b/skills/pr-shepherd/scripts/wait_for_settle.sh
@@ -84,6 +84,15 @@ TIMEOUT_BIN=""
 if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN=timeout
 elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout; fi
 
+# The watchdog read (used only when there's no timeout binary) reaps a hung
+# child — the real `gh` process — with pkill -P. Without pkill that child can
+# orphan, so warn once if this fallback would run without either tool.
+PKILL_BIN=""
+command -v pkill >/dev/null 2>&1 && PKILL_BIN=pkill
+if [ -z "$TIMEOUT_BIN" ] && [ -z "$PKILL_BIN" ]; then
+  echo "wait_for_settle: no timeout/gtimeout or pkill found — a hung gate read stays bounded, but its gh child may orphan. Install coreutils (timeout) or procps (pkill) to avoid leaks." >&2
+fi
+
 # Read the gate, bounding it by READ_TIMEOUT so a hung gh call surfaces as exit
 # 124 (treated as a transient, retryable error) instead of blocking --max-wait
 # forever. With a timeout binary that bound is one exec; without one, a
@@ -94,22 +103,26 @@ read_gate() {
     "$TIMEOUT_BIN" "$READ_TIMEOUT" "$STATUS" "$@"
     return $?
   fi
-  local out waited=0 pid rc
+  local out err waited=0 pid rc
   out="$(mktemp "${TMPDIR:-/tmp}/wfs.XXXXXX")" || return 50
-  "$STATUS" "$@" >"$out" 2>/dev/null &
+  err="$(mktemp "${TMPDIR:-/tmp}/wfs.XXXXXX")" || { rm -f "$out"; return 50; }
+  # Redirect both streams to files (not inherited fds): an unreaped child can't
+  # then hold a caller's pipe open, and pr_status.sh's stderr is still surfaced
+  # afterward so its diagnostics (e.g. the truncation warning) stay visible.
+  "$STATUS" "$@" >"$out" 2>"$err" &
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$waited" -ge "$READ_TIMEOUT" ]; then
-      pkill -P "$pid" 2>/dev/null || true   # reap the hung child (e.g. gh) first
+      [ -n "$PKILL_BIN" ] && "$PKILL_BIN" -P "$pid" 2>/dev/null || true  # reap the hung child (e.g. gh)
       kill "$pid" 2>/dev/null || true
       wait "$pid" 2>/dev/null || true
-      cat "$out"; rm -f "$out"
+      cat "$out"; cat "$err" >&2; rm -f "$out" "$err"
       return 124
     fi
     sleep 1; waited=$((waited + 1))
   done
   wait "$pid"; rc=$?
-  cat "$out"; rm -f "$out"
+  cat "$out"; cat "$err" >&2; rm -f "$out" "$err"
   return "$rc"
 }
 


### PR DESCRIPTION
## What & why

`pr-shepherd` waited on CI with a single `gh pr checks --watch`, which reacts only to checks — not to mergeability still computing or review/thread changes — so a PR stuck in `WAITING_CI` for a non-CI reason could spin against the 5-iteration cap. This replaces that step with a bounded, spin-safe wait helper, and documents an optional webhook mode (researched, deliberately not the default).

`pr_status.sh` (the strict GREEN gate) and the loop's GREEN definition are unchanged.

## Changes

- **`scripts/wait_for_settle.sh`** (new) — wraps the existing gate: blocks on `gh pr checks --watch` while checks are pending, interval-polls the gate otherwise, so it also wakes on mergeability/review changes. Bounded by `--max-wait` (resumable on timeout), spin-guarded, and time-boxes each gate read so a hung `gh` call retries instead of blocking.
- **`SKILL.md`** — `WAITING_CI` branch now calls the helper; added wait knobs and a pointer to the webhook mode.
- **`references/github-api.md` §11** — documents `gh webhook forward` as an admin-only opt-in *wake signal* (the gate still decides merge), with caveats (repo admin, foreground daemon, dev-only, no GHES).

## Why polling, not webhooks, by default

Webhooks need repo admin to create the hook and a long-running local receiver — at odds with the skill's "may run on an API/MCP surface" contract — and their only edge over `--watch` (waking on review/branch events) is had more cheaply by re-reading the gate. So webhooks are an escape hatch, not the default.

## Verification

- 6 deterministic control-flow tests (settled verdicts, the spin fix, bounded timeout, no-timeout polling fallback) plus a live read against a real PR.
- `--max-wait` is honored on every platform: via `timeout`/`gtimeout` where present, via a polling fallback where absent (e.g. default macOS).
- `bash -n` and `prettier --check` clean.

Two correctness issues found by Codex review — an unbounded watch ignoring `--max-wait`, and watching the cwd repo instead of the target — are fixed and covered by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsTYDPdvvSYetTcnEDLeZj
