### PR TITLE
🐛 fix(orchestrate-agents): correct usage against codex 0.146

### DIFF
--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -63,10 +63,14 @@ git rev-parse --verify -q "$BASE" >/dev/null || { echo "base '$BASE' not found" 
 TIMEOUT=$(command -v timeout || command -v gtimeout) ||
   { echo "no GNU timeout — macOS: brew install coreutils" >&2; exit 1; }
 
-# CODEX_HOME picks which codex account the fan-out spends, and nothing else does. Workers
-# inherit your environment, so naming it here is how you keep a wide run off the wrong
-# profile's quota. See "Which codex account pays" below.
-export CODEX_HOME=${CODEX_HOME:-$HOME/.codex}
+# CODEX_HOME picks which codex account the fan-out spends. Demand it rather than defaulting:
+# an inherited value silently spends the wrong profile, which is the failure this guards. And
+# CODEX_API_KEY outranks the pinned profile in this lane, so drop it. See "CODEX_HOME selects
+# the profile" below.
+export CODEX_HOME=${CODEX_HOME:?name the codex profile to spend from, e.g. $HOME/.codex}
+[ -f "$CODEX_HOME/auth.json" ] ||
+  { echo "no auth.json in $CODEX_HOME — wrong profile?" >&2; exit 1; }
+unset CODEX_API_KEY
 
 # One result contract, consumed differently: codex takes a path, grok takes the text.
 cat > "$RUN/result.schema.json" <<'JSON'
@@ -165,24 +169,44 @@ with shell access — a worker that misreads its file scope can reach the siblin
 your other parallel tasks. Pair it with `--sandbox` (or `GROK_SANDBOX`) so something is
 still holding the boundary.
 
-**Which codex account pays is `CODEX_HOME`, and only `CODEX_HOME`.** No CLI flag selects it:
-`-p/--profile` layers `$CODEX_HOME/<name>.config.toml`, which switches _config_ and never
-credentials — even `--ignore-user-config` keeps reading auth from `CODEX_HOME`. Where several
-profiles are logged in on one machine, `codex login status` cannot tell them apart: it prints
-the same `Logged in using ChatGPT` for every profile directory, and stays silent about an
-`OPENAI_API_KEY` sitting in the environment — which applies no matter which profile you chose,
-so a fan-out you believe is spending subscription quota can be billing metered API instead.
-`codex doctor` is what discloses this, warning `mixed auth signals` and breaking out `auth env
-vars present`, `stored auth mode`, and `reachability mode`. Pin `CODEX_HOME` per run rather
-than trusting whatever the supervising shell inherited.
+**`CODEX_HOME` selects the profile, but it does not defend it.** No CLI flag selects the
+account: `-p/--profile` layers `$CODEX_HOME/<name>.config.toml`, which switches _config_ and
+never credentials — even `--ignore-user-config` keeps reading auth from `CODEX_HOME`. What
+`CODEX_HOME` cannot do is stop an environment variable outranking the profile you pinned.
+Measured precedence in `codex exec`: a provider's own `env_key` beats **`CODEX_API_KEY`**,
+which beats the stored ChatGPT login. Export `CODEX_API_KEY` and every worker bills metered
+API from a profile whose `auth.json` still says `chatgpt` — so `unset` it, or launch through
+`env -u CODEX_API_KEY`.
+
+`OPENAI_API_KEY` is _not_ that variable, which is worth knowing precisely because it looks
+like it should be. On 0.146.0 the built-in `openai` provider sets no `env_key`, so exporting
+`OPENAI_API_KEY` changes nothing about who pays: a bogus value produces byte-identical
+behaviour to no value at all. It only flips `codex doctor`'s own HTTP probe, which is why
+doctor can warn `mixed auth signals` on a run that is spending pure subscription quota.
+
+That makes `codex login status` useless for this: it prints the same `Logged in using ChatGPT`
+for every profile directory and says nothing about either variable. Read `codex doctor`
+instead — and read the right row. `auth mode`, under Connectivity, is the credential a turn
+actually spends; `reachability mode` describes only the probe, and `auth env vars present`
+reports presence, never precedence:
+
+```bash
+codex doctor --json | jq -r '.checks[]|select(.id=="network.websocket_reachability").details["auth mode"]'
+```
+
+Scope that to Lane A. On this build the app-server lane ignored `CODEX_API_KEY` and spent the
+stored login anyway, while doctor still reported `api_key` — so treat the row as an answer
+about `codex exec`, and keep the `unset` in both lanes rather than relying on the difference.
 
 **Check the exit status, not just the output.** When `timeout` fires, codex is killed
 mid-stream: the JSONL never reaches `turn.completed` and `-o` is never written, which looks
 identical to a crash or a bad schema path. The exit code is the only signal: 124 when
 SIGTERM ended it, 137 when `-k` escalated to SIGKILL (measured on GNU coreutils 9.4). Do not
 lean too hard on 137 though — an OOM kill or a CI runner reaping the job produces it too.
-Treat any non-zero code as "no usable result", read the `.err` file for the reason, and
-remember the worktree still holds partial, uncommitted edits either way.
+Treat any non-zero code as "no usable result", then look for the reason in the JSONL first —
+`turn.failed` and `error` carry it, and a schema rejection puts it there while leaving `.err`
+empty. Fall back to `.err` only for failures that never reached the protocol at all. Either
+way the worktree still holds partial, uncommitted edits.
 
 Keep stderr in its own file. Both machine-readable outputs are parsed structurally, so
 folding diagnostics into them with `2>&1` corrupts the parse — including the harmless
@@ -207,12 +231,36 @@ the agent's working root but not the CLI's own path resolution: both `--output-s
 worktree — an artifact written inside it leaves the tree dirty, and `git worktree remove`
 then refuses without `--force`.
 
-**Rule 6 has a purpose-built lane on the codex side.** `codex exec review --base "$BASE"`
-reviews a branch against its base headlessly and takes the same `--json` / `-o` /
-`--output-schema` plumbing as `codex exec`; `--uncommitted` and `--commit <SHA>` narrow the
-scope instead. Because it reads a diff rather than a conversation, it strips the implementer's
-self-assessment by construction. It only satisfies rule 6 when codex is the _reviewer_ — when
-codex wrote the code, the diff still goes to grok.
+**Rule 6 has a purpose-built lane on the codex side.** `codex exec review` reviews headlessly
+and keeps the same `--json` / `-o` / `--output-schema` plumbing as `codex exec`. Because it
+reads a diff rather than a conversation, it strips the implementer's self-assessment by
+construction. It only satisfies rule 6 when codex is the _reviewer_ — when codex wrote the
+code, the diff still goes to grok.
+
+Three things about it will bite on first use:
+
+```bash
+# Parent-level flags go BEFORE `review` — the subcommand has no -C, -p, -s, --add-dir, -i.
+codex exec -C "$WORKTREES/$t" review --base "$BASE" --json -o "$LOG/$t.review.txt"
+# codex exec review -C … → error: unexpected argument '-C' found
+```
+
+1. **The target and a prompt are mutually exclusive.** `--base`, `--uncommitted`, `--commit`,
+   and a free-form `[PROMPT]` are four ways to name one `ReviewTarget`, so you get exactly
+   one: `error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'` (exit 2). Flag
+   ordering will not save you, and `-` reads as a prompt, so stdin is not a way around it.
+2. **So `--base` cannot carry the spec** that rule 6 asks for. Use the prompt form instead and
+   let the reviewer resolve the diff itself — `codex exec -C "$WORKTREES/$t" review "<spec>.
+   Review the diff of HEAD against $BASE."` A repo `AGENTS.md` also reaches the review turn
+   (verified in its rollout), but that is the human-written channel of rule 7, not somewhere
+   a supervisor writes a per-task spec.
+3. **A `--base` that does not resolve fails quietly**, unlike the script's own `rev-parse`
+   guard: codex swaps in a fallback prompt telling the model to work out the merge base, so a
+   typo'd branch yields a plausible review of the wrong range. `--title` is silently dropped
+   here too — it survives only on `--commit`.
+
+`codex review` is a thinner subcommand, not an alias: no `--json`, no `-o`, no
+`--output-schema`. For orchestration, always reach for `codex exec review`.
 
 Also useful: `--ephemeral` and `--ignore-user-config` / `--ignore-rules` for hermetic runs,
 `--strict-config` to make an unrecognized config key an error rather than a silent ignore,
@@ -222,9 +270,12 @@ plus `grok worktree list|rm|gc`.
 ## Lane B
 
 Lifecycle: `initialize` → `initialized` → `thread/start` → `turn/start` → notifications →
-`turn/completed`. Newline-delimited JSON-RPC 2.0 request/response/notification shapes, but
-the `jsonrpc: "2.0"` version field is omitted — treat it as JSON-RPC-style framing, not a
-conformant JSON-RPC 2.0 endpoint, and do not send the field yourself.
+`turn/completed`. JSON-RPC 2.0 request/response/notification shapes, but the `jsonrpc: "2.0"`
+version field is omitted — treat it as JSON-RPC-style, not a conformant JSON-RPC 2.0
+endpoint, and do not send the field yourself.
+
+The messages are the same on every transport; the _framing_ is not. Newline-delimited JSON is
+`stdio://` only — everything below assumes it.
 
 Generate the protocol from the installed binary rather than trusting any list — it moves
 between releases:
@@ -241,8 +292,23 @@ you are hunting for a capability, but do not build a supervisor on one: the flag
 precisely because they move without notice.
 
 `--stdio` is shorthand for `--listen stdio://`. `--listen` also takes `unix://PATH` and
-`ws://IP:PORT`, which is what you want if the supervisor and the server are not
-parent-and-child processes.
+`ws://IP:PORT` for a supervisor that is not the server's parent — but **both speak WebSocket,
+not newline-delimited JSON**. Write the stdio bytes at either and you get silence (unix) or
+`HTTP/1.1 400 Bad Request` (ws); they want an RFC 6455 upgrade, after which each message is
+one text frame and the newline stops being a delimiter. The cheap way out is
+`codex app-server proxy --sock <path>`, which bridges your existing stdio client onto the
+socket and does the upgrade for you.
+
+Non-loopback `ws://` is not the open door it looks like: binding anything but loopback
+_refuses to start_ without `--ws-auth capability-token` (plus `--ws-token-file` /
+`--ws-token-sha256`) or `--ws-auth signed-bearer-token` (plus `--ws-shared-secret-file`). The
+credential rides the upgrade's `Authorization: Bearer` header and a bad one gets a 401 before
+any JSON-RPC, so `initialize` carrying no credential does not mean the surface is unguarded.
+Requests arriving with any `Origin` header are refused outright, which shuts the browser and
+DNS-rebinding path. What is genuinely exposed is confidentiality: there is no `wss://` and no
+TLS flag, so prompts, diffs, and the bearer token itself travel in clear text — tunnel it, or
+prefer `unix://PATH` when both ends share a host. A loopback `ws://` with no `--ws-auth` is
+unauthenticated by design, which is worth remembering on a multi-user box.
 
 What Lane B uniquely buys: `turn/steer` (inject correction mid-turn), `turn/interrupt`,
 `thread/fork` (variants off a shared prefix), `account/rateLimits/read`, and
@@ -266,9 +332,9 @@ assuming N× throughput.
 - **codex** — well-specified repo-local implementation. No turn cap: bound it with
   `timeout` externally. Check the auth mode before sizing a fan-out: a ChatGPT-logged-in
   session spends subscription quota, but an API key — stored via `codex login --with-api-key`
-  or merely exported as `OPENAI_API_KEY` — bills metered usage, so the same fan-out becomes
-  cash. `codex doctor` tells you which, and warns when both are in play; `codex login status`
-  does not.
+  or exported as `CODEX_API_KEY`, which outranks the stored login — bills metered usage, so
+  the same fan-out becomes cash. `codex doctor`'s `auth mode` row tells you which; `codex
+  login status` does not.
 - **grok** — bounded mechanical breadth: tests, repetitive multi-file edits, exploration.
   `--max-turns` gives a hard budget, and its JSON reports `total_cost_usd`. Metered, so
   watch the number.
@@ -291,9 +357,9 @@ these runs fail.
 4. **Hard budgets always** — `--max-turns` on grok, `timeout` plus `turn/interrupt` on
    codex. Unbounded tool chaining is the classic way to burn an afternoon and a quota.
 5. **Pre-flight the budget** before a wide fan-out, by whatever the lane affords. In Lane A
-   that means `codex doctor` under the `CODEX_HOME` you are about to spend — not `codex login
-   status`, which cannot distinguish profiles and hides an `OPENAI_API_KEY` override —
-   plus grok's `total_cost_usd` from the previous batch. A real quota figure needs
+   that means `codex doctor`'s `auth mode` row under the `CODEX_HOME` you are about to spend
+   — not `codex login status`, which cannot distinguish profiles and hides a `CODEX_API_KEY`
+   override — plus grok's `total_cost_usd` from the previous batch. A real quota figure needs
    `account/rateLimits/read`, which is Lane B; one short app-server handshake gets it without
    adopting Lane B for the actual work.
 6. **Whoever writes, someone else reviews.** Each model finds more bugs in the other's

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -107,7 +107,7 @@ for spec in "${TASKS[@]}"; do
   t=${spec%%:*} lane=${spec##*:}
   # Drop last run's artifacts for this task, or a skip leaves stale results that read as
   # this run's — the same trap the exit-codes truncation above avoids.
-  rm -f "$LOG/$t".{jsonl,json,err,last.txt}
+  rm -f "$LOG/$t".{jsonl,json,err,last.txt} "$LOG/$t".review.{jsonl,txt,err}
   # Check the brief BEFORE creating anything, or a missing one leaves an orphaned worktree
   # that makes every later re-run of this task fail at `add`.
   [ -s "$BRIEFS/$t.md" ] || { echo "$t no-brief" >> "$LOG/exit-codes"; continue; }
@@ -262,8 +262,10 @@ Three things about it will bite on first use:
 ```bash
 # Parent-level flags go BEFORE `review` — the subcommand has no -C, -p, -s, --add-dir, -i.
 # The spec rides in positionally, which is the only shape that carries spec AND diff (2 below).
-# It is still a `codex exec` turn: no turn cap (rule 4), and --json needs its own redirect.
-"$TIMEOUT" -k 30s 30m codex exec -C "$WORKTREES/$t" review \
+# It is still a `codex exec` turn: no turn cap (rule 4), --json needs its own redirect, and
+# the account guard applies here too — this lane runs once per reviewed task.
+"$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY \
+  codex exec -C "$WORKTREES/$t" review \
   --json -o "$LOG/$t.review.txt" \
   "$(cat "$BRIEFS/$t.md")
 Review the diff of HEAD against $BASE against that spec." < /dev/null \
@@ -377,8 +379,8 @@ assuming N× throughput.
   `timeout` externally. Check the auth mode before sizing a fan-out: a ChatGPT-logged-in
   session spends subscription quota, but an API key — stored via `codex login --with-api-key`
   or exported as `CODEX_API_KEY`, which outranks the stored login — bills metered usage, so
-  the same fan-out becomes cash. `codex doctor`'s `auth mode` row tells you which; `codex
-login status` does not.
+  the same fan-out becomes cash. `codex doctor`'s `auth mode` row tells you which.
+  `codex login status` does not.
 - **grok** — bounded mechanical breadth: tests, repetitive multi-file edits, exploration.
   `--max-turns` gives a hard budget, and its JSON reports `total_cost_usd`. Metered, so
   watch the number.
@@ -405,10 +407,11 @@ these runs fail.
    — not `codex login status`, which cannot distinguish profiles and hides a `CODEX_API_KEY`
    override — plus grok's `total_cost_usd` from the previous batch. A real quota figure needs
    `account/rateLimits/read`, which is Lane B; one short app-server handshake gets it without
-   adopting Lane B for the actual work. Start that handshake with `CODEX_API_KEY` unset, as
-   `run_codex` does — the app-server lane ignores the variable, so otherwise it hands you the
-   stored login's quota while the workers bill metered API, reassuring you in exactly the case
-   that costs money.
+   adopting Lane B for the actual work. That figure only describes the stored login, because
+   the handshake ignores `CODEX_API_KEY` — so it is trustworthy exactly when the workers spend
+   the same credential, which is what `run_codex`'s `env -u` guarantees. Drop that `env -u` and
+   the number stops meaning anything: check `codex doctor`'s `auth mode` in the workers' own
+   environment instead of reading rate limits at all.
 6. **Whoever writes, someone else reviews.** Each model finds more bugs in the other's
    code than its own. Give the reviewer the spec and the diff — strip the implementer's
    own assessment, which measurably softens review depth. When codex is the reviewer,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -63,6 +63,11 @@ git rev-parse --verify -q "$BASE" >/dev/null || { echo "base '$BASE' not found" 
 TIMEOUT=$(command -v timeout || command -v gtimeout) ||
   { echo "no GNU timeout — macOS: brew install coreutils" >&2; exit 1; }
 
+# CODEX_HOME picks which codex account the fan-out spends, and nothing else does. Workers
+# inherit your environment, so naming it here is how you keep a wide run off the wrong
+# profile's quota. See "Which codex account pays" below.
+export CODEX_HOME=${CODEX_HOME:-$HOME/.codex}
+
 # One result contract, consumed differently: codex takes a path, grok takes the text.
 cat > "$RUN/result.schema.json" <<'JSON'
 {
@@ -160,6 +165,17 @@ with shell access — a worker that misreads its file scope can reach the siblin
 your other parallel tasks. Pair it with `--sandbox` (or `GROK_SANDBOX`) so something is
 still holding the boundary.
 
+**Which codex account pays is `CODEX_HOME`, and only `CODEX_HOME`.** No CLI flag selects it:
+`-p/--profile` layers `$CODEX_HOME/<name>.config.toml`, which switches _config_ and never
+credentials — even `--ignore-user-config` keeps reading auth from `CODEX_HOME`. Where several
+profiles are logged in on one machine, `codex login status` cannot tell them apart: it prints
+the same `Logged in using ChatGPT` for every profile directory, and stays silent about an
+`OPENAI_API_KEY` sitting in the environment — which applies no matter which profile you chose,
+so a fan-out you believe is spending subscription quota can be billing metered API instead.
+`codex doctor` is what discloses this, warning `mixed auth signals` and breaking out `auth env
+vars present`, `stored auth mode`, and `reachability mode`. Pin `CODEX_HOME` per run rather
+than trusting whatever the supervising shell inherited.
+
 **Check the exit status, not just the output.** When `timeout` fires, codex is killed
 mid-stream: the JSONL never reaches `turn.completed` and `-o` is never written, which looks
 identical to a crash or a bad schema path. The exit code is the only signal: 124 when
@@ -237,6 +253,10 @@ running with `--dangerously-bypass-*`.
 `thread/start` takes per-thread `cwd`, `sandbox`, `model`, `baseInstructions`,
 `ephemeral`; `turn/start` takes per-turn `cwd`, `model`, `effort`, `outputSchema`.
 
+Neither takes an account: auth comes from the process's `CODEX_HOME`, so one server is one
+profile, and a fan-out across profiles needs a server each. The `initialize` response echoes
+`codexHome` back, which is the cheapest way to assert you attached to the one you meant.
+
 One process does run threads concurrently, but with contention — four threads were
 observed overlapping cleanly yet finishing non-linearly. Measure your own workload before
 assuming N× throughput.
@@ -245,8 +265,10 @@ assuming N× throughput.
 
 - **codex** — well-specified repo-local implementation. No turn cap: bound it with
   `timeout` externally. Check the auth mode before sizing a fan-out: a ChatGPT-logged-in
-  session spends subscription quota, but `codex login --with-api-key` bills metered API
-  usage, so the same fan-out becomes cash. `codex login status` tells you which.
+  session spends subscription quota, but an API key — stored via `codex login --with-api-key`
+  or merely exported as `OPENAI_API_KEY` — bills metered usage, so the same fan-out becomes
+  cash. `codex doctor` tells you which, and warns when both are in play; `codex login status`
+  does not.
 - **grok** — bounded mechanical breadth: tests, repetitive multi-file edits, exploration.
   `--max-turns` gives a hard budget, and its JSON reports `total_cost_usd`. Metered, so
   watch the number.
@@ -269,10 +291,11 @@ these runs fail.
 4. **Hard budgets always** — `--max-turns` on grok, `timeout` plus `turn/interrupt` on
    codex. Unbounded tool chaining is the classic way to burn an afternoon and a quota.
 5. **Pre-flight the budget** before a wide fan-out, by whatever the lane affords. In Lane A
-   that means `codex login status` (subscription quota or metered API key — the two fail
-   very differently) plus grok's `total_cost_usd` from the previous batch. A real quota
-   figure needs `account/rateLimits/read`, which is Lane B; one short app-server handshake
-   gets it without adopting Lane B for the actual work.
+   that means `codex doctor` under the `CODEX_HOME` you are about to spend — not `codex login
+   status`, which cannot distinguish profiles and hides an `OPENAI_API_KEY` override —
+   plus grok's `total_cost_usd` from the previous batch. A real quota figure needs
+   `account/rateLimits/read`, which is Lane B; one short app-server handshake gets it without
+   adopting Lane B for the actual work.
 6. **Whoever writes, someone else reviews.** Each model finds more bugs in the other's
    code than its own. Give the reviewer the spec and the diff — strip the implementer's
    own assessment, which measurably softens review depth. When codex is the reviewer,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -68,6 +68,11 @@ TIMEOUT=$(command -v timeout || command -v gtimeout) ||
 # A custom provider's own `env_key` outranks even that, so assert the resolved account with
 # rule 5's `codex doctor` query before a wide run. See "CODEX_HOME selects the profile" below.
 CODEX_HOME=${CODEX_HOME:-$HOME/.codex}; export CODEX_HOME
+# Strip CODEX_API_KEY only when a stored login is what we mean to spend. Deriving this from
+# the same file the guard below tests keeps the two in step: where the key IS the credential
+# (CI), it survives, and the doctor query run through CODEX_ENV still answers about workers.
+CODEX_ENV=(env -u CODEX_API_KEY)
+[ -f "$CODEX_HOME/auth.json" ] || CODEX_ENV=(env)
 
 # One result contract, consumed differently: codex takes a path, grok takes the text.
 cat > "$RUN/result.schema.json" <<'JSON'
@@ -86,7 +91,7 @@ JSON
 run_codex() { # $1 = task id
   # codex has no turn cap, so `timeout` is the budget (rule 4). -k reaps a worker that
   # ignores SIGTERM; exit 124 means the budget fired, not that the task failed.
-  "$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY \
+  "$TIMEOUT" -k 30s 30m "${CODEX_ENV[@]}" \
     codex exec --json --sandbox workspace-write \
     -C "$WORKTREES/$1" --output-schema "$RUN/result.schema.json" -o "$LOG/$1.last.txt" \
     "$(cat "$BRIEFS/$1.md")" < /dev/null \
@@ -119,10 +124,10 @@ for spec in "${TASKS[@]}"; do
     codex | grok) ;;
     *) echo "$t bad-lane-$lane" >> "$LOG/exit-codes"; continue ;;
   esac
-  # Only codex tasks need the account, so an all-grok fan-out runs fine without codex. Accept
-  # either credential: a stored login, or CODEX_API_KEY where that IS the credential (CI,
-  # typically) — in which case also drop `run_codex`'s `env -u`, and accept that the two then
-  # bill differently. Never paper over a missing account by creating an empty auth.json.
+  # Only codex tasks need the account, so an all-grok fan-out runs fine without codex. Either
+  # credential counts — a stored login, or CODEX_API_KEY where that IS the credential (CI);
+  # CODEX_ENV above already keeps the launcher in step, so there is nothing to edit by hand.
+  # Never paper over a missing account by creating an empty auth.json.
   if [ "$lane" = codex ] && [ ! -f "$CODEX_HOME/auth.json" ] && [ -z "$CODEX_API_KEY" ]; then
     echo "$t no-codex-auth-in-$CODEX_HOME" >> "$LOG/exit-codes"; continue
   fi
@@ -210,9 +215,13 @@ actually spends; `reachability mode` describes only the probe, and `auth env var
 reports presence, never precedence:
 
 ```bash
-# Mirror `run_codex`'s `env -u`, or you measure your own credential rather than the workers'.
-env -u CODEX_API_KEY codex doctor --json |
-  jq -r '.checks[]|select(.id=="network.websocket_reachability").details["auth mode"]'
+# Run it through CODEX_ENV, or you measure your own credential rather than the workers'.
+# `jq -e` matters as much: a renamed check id would otherwise print nothing and exit 0,
+# turning the guard against an accidental metered fan-out into a silent pass.
+AUTH=$("${CODEX_ENV[@]}" codex doctor --json |
+  jq -er '.checks[]|select(.id=="network.websocket_reachability").details["auth mode"]') ||
+  { echo "cannot read auth mode from codex doctor" >&2; exit 1; }
+echo "$AUTH" # chatgpt = subscription quota, api_key = metered
 ```
 
 Scope that to Lane A. On this build the app-server lane ignored `CODEX_API_KEY` and spent the
@@ -266,7 +275,7 @@ Three things about it will bite on first use:
 # The spec rides in positionally, which is the only shape that carries spec AND diff (2 below).
 # It is still a `codex exec` turn: no turn cap (rule 4), --json needs its own redirect, and
 # the account guard applies here too — this lane runs once per reviewed task.
-"$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY \
+"$TIMEOUT" -k 30s 30m "${CODEX_ENV[@]}" \
   codex exec -C "$WORKTREES/$t" review \
   --json -o "$LOG/$t.review.txt" \
   "$(cat "$BRIEFS/$t.md")
@@ -353,7 +362,10 @@ multi-user box every local account can reach that approval surface. Two fixes, b
 codex app-server --listen unix://"${XDG_RUNTIME_DIR:-$HOME}"/codex-as.sock
 
 # Or keep ws:// and authenticate it. --ws-auth is honoured on loopback too: without the
-# header the upgrade gets 401, with it 101.
+# header the upgrade gets 401, with it 101. The token file is then the whole boundary, so
+# create it under a tight umask — the default 0644 hands the capability to every local
+# account, which is the exposure this block exists to close. Same for the shared-secret file.
+(umask 077; openssl rand -hex 32 > ~/.config/codex-as.token)
 codex app-server --listen ws://127.0.0.1:7777 \
   --ws-auth capability-token --ws-token-file ~/.config/codex-as.token
 ```

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -112,8 +112,17 @@ for spec in "${TASKS[@]}"; do
   # that makes every later re-run of this task fail at `add`.
   [ -s "$BRIEFS/$t.md" ] || { echo "$t no-brief" >> "$LOG/exit-codes"; continue; }
   # Every other precondition belongs here too, for exactly that reason — a worker that
-  # cannot start must not leave a tree and branch behind. Only codex tasks need the account,
-  # so an all-grok fan-out runs fine on a host without codex.
+  # cannot start must not leave a tree and branch behind. An unknown lane is one of them:
+  # `${spec##*:}` returns the whole string when the colon is missing, and `run_<that>` would
+  # die as 127 in the background, recording nothing and orphaning the tree.
+  case $lane in
+    codex | grok) ;;
+    *) echo "$t bad-lane-$lane" >> "$LOG/exit-codes"; continue ;;
+  esac
+  # Only codex tasks need the account, so an all-grok fan-out runs fine without codex. This
+  # deliberately demands a stored login: `run_codex` strips CODEX_API_KEY, so on a host where
+  # that variable IS the credential (CI, typically), drop the `env -u` and accept metered
+  # billing — do not just create an empty auth.json.
   if [ "$lane" = codex ] && [ ! -f "$CODEX_HOME/auth.json" ]; then
     echo "$t no-codex-auth-in-$CODEX_HOME" >> "$LOG/exit-codes"; continue
   fi
@@ -329,8 +338,10 @@ Loopback is the case to actually think about, because there the refusal does not
 multi-user box every local account can reach that approval surface. Two fixes, both verified:
 
 ```bash
-# Best — the socket is created srw------- (0600), so file permissions do the gating.
-codex app-server --listen unix://"$XDG_RUNTIME_DIR"/codex-as.sock
+# Best — the socket is created srw------- (0600), so file permissions do the gating. Keep it
+# on a private path: XDG_RUNTIME_DIR is unset on macOS and non-systemd hosts, and unguarded
+# the path would collapse to unix:///codex-as.sock at the filesystem root.
+codex app-server --listen unix://"${XDG_RUNTIME_DIR:-$HOME}"/codex-as.sock
 
 # Or keep ws:// and authenticate it. --ws-auth is honoured on loopback too: without the
 # header the upgrade gets 401, with it 101.

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -41,7 +41,7 @@ same worktree is the collision rule 1 exists to prevent, so codex and grok below
 alternatives per task, never both on the same task.
 
 ```bash
-TASKS=(auth-refresh api-pagination) # one id per independent task
+TASKS=(auth-refresh:codex api-pagination:grok) # "<id>:<lane>", one per independent task
 
 # Keep worktrees and logs OUTSIDE the supervised repo — nesting them under it puts every
 # delegate's tree inside your own working tree and pollutes status/ignore rules.
@@ -63,6 +63,12 @@ git rev-parse --verify -q "$BASE" >/dev/null || { echo "base '$BASE' not found" 
 TIMEOUT=$(command -v timeout || command -v gtimeout) ||
   { echo "no GNU timeout — macOS: brew install coreutils" >&2; exit 1; }
 
+# Resolve the codex account up front so the loop can check it before creating anything. No
+# CLI flag selects it, and CODEX_API_KEY outranks it — `run_codex` drops that per invocation.
+# A custom provider's own `env_key` outranks even that, so assert the resolved account with
+# rule 5's `codex doctor` query before a wide run. See "CODEX_HOME selects the profile" below.
+CODEX_HOME=${CODEX_HOME:-$HOME/.codex}; export CODEX_HOME
+
 # One result contract, consumed differently: codex takes a path, grok takes the text.
 cat > "$RUN/result.schema.json" <<'JSON'
 {
@@ -78,17 +84,9 @@ cat > "$RUN/result.schema.json" <<'JSON'
 JSON
 
 run_codex() { # $1 = task id
-  # CODEX_HOME names the account this spends and no CLI flag does — but guard it inside the
-  # lane, or an all-grok fan-out dies here on a host without codex. `-u CODEX_API_KEY` closes
-  # the env override; a custom provider's own `env_key` outranks even that, so assert the
-  # account with rule 5's `codex doctor` query before going wide. See "CODEX_HOME selects the
-  # profile" below.
-  local home=${CODEX_HOME:-$HOME/.codex}
-  [ -f "$home/auth.json" ] ||
-    { echo "$1 no-codex-auth-in-$home" >> "$LOG/exit-codes"; return; }
   # codex has no turn cap, so `timeout` is the budget (rule 4). -k reaps a worker that
   # ignores SIGTERM; exit 124 means the budget fired, not that the task failed.
-  "$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY CODEX_HOME="$home" \
+  "$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY \
     codex exec --json --sandbox workspace-write \
     -C "$WORKTREES/$1" --output-schema "$RUN/result.schema.json" -o "$LOG/$1.last.txt" \
     "$(cat "$BRIEFS/$1.md")" < /dev/null \
@@ -105,20 +103,27 @@ run_grok() { # $1 = task id
   echo "$1 $?" >> "$LOG/exit-codes"
 }
 
-for t in "${TASKS[@]}"; do
+for spec in "${TASKS[@]}"; do
+  t=${spec%%:*} lane=${spec##*:}
   # Drop last run's artifacts for this task, or a skip leaves stale results that read as
   # this run's — the same trap the exit-codes truncation above avoids.
   rm -f "$LOG/$t".{jsonl,json,err,last.txt}
   # Check the brief BEFORE creating anything, or a missing one leaves an orphaned worktree
   # that makes every later re-run of this task fail at `add`.
   [ -s "$BRIEFS/$t.md" ] || { echo "$t no-brief" >> "$LOG/exit-codes"; continue; }
+  # Every other precondition belongs here too, for exactly that reason — a worker that
+  # cannot start must not leave a tree and branch behind. Only codex tasks need the account,
+  # so an all-grok fan-out runs fine on a host without codex.
+  if [ "$lane" = codex ] && [ ! -f "$CODEX_HOME/auth.json" ]; then
+    echo "$t no-codex-auth-in-$CODEX_HOME" >> "$LOG/exit-codes"; continue
+  fi
   # Never launch a worker into a tree you failed to create — on a re-run the add fails
   # ("already exists") and an unguarded worker would edit whatever is sitting there.
   git worktree add "$WORKTREES/$t" -b "feat/$t" "$BASE" || {
     echo "$t skipped-no-worktree" >> "$LOG/exit-codes"
     continue
   }
-  run_codex "$t" & # or run_grok "$t" — pick one per task
+  "run_$lane" "$t" &
 done
 wait
 
@@ -317,8 +322,21 @@ any JSON-RPC, so `initialize` carrying no credential does not mean the surface i
 Requests arriving with any `Origin` header are refused outright, which shuts the browser and
 DNS-rebinding path. What is genuinely exposed is confidentiality: there is no `wss://` and no
 TLS flag, so prompts, diffs, and the bearer token itself travel in clear text — tunnel it, or
-prefer `unix://PATH` when both ends share a host. A loopback `ws://` with no `--ws-auth` is
-unauthenticated by design, which is worth remembering on a multi-user box.
+prefer `unix://PATH` when both ends share a host.
+
+Loopback is the case to actually think about, because there the refusal does not fire: a
+`ws://127.0.0.1` listener with no `--ws-auth` is unauthenticated by design, and on a
+multi-user box every local account can reach that approval surface. Two fixes, both verified:
+
+```bash
+# Best — the socket is created srw------- (0600), so file permissions do the gating.
+codex app-server --listen unix://"$XDG_RUNTIME_DIR"/codex-as.sock
+
+# Or keep ws:// and authenticate it. --ws-auth is honoured on loopback too: without the
+# header the upgrade gets 401, with it 101.
+codex app-server --listen ws://127.0.0.1:7777 \
+  --ws-auth capability-token --ws-token-file ~/.config/codex-as.token
+```
 
 What Lane B uniquely buys: `turn/steer` (inject correction mid-turn), `turn/interrupt`,
 `thread/fork` (variants off a shared prefix), `account/rateLimits/read`, and

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -136,9 +136,10 @@ nobody has reviewed it yet.
 
 **codex validates `--output-schema` in strict mode.** Every key in `properties` must also
 appear in `required`, and `additionalProperties` must be `false`. Omit one and the turn dies
-with `invalid_json_schema` before any work happens — the run fails fast, but only the stderr
-file and a `turn.failed` event say why. Model optional fields as nullable types, not as
-absent-from-`required`.
+with `invalid_json_schema` before any work happens. The reason lands in the JSONL — once as an
+`error` event, again on `turn.failed` — and _not_ in the `.err` file, which stays empty. A
+supervisor that reads only stderr sees a silent failure. Model optional fields as nullable
+types, not as absent-from-`required`.
 
 **The delegate commits; you review and merge.** Rule 3 assumes each task branch exists when
 its worker exits, so say so in the brief. A linked worktree's `.git` is a gitfile pointing
@@ -177,6 +178,13 @@ corrupts the brief.
 
 codex JSONL: `thread.started` → `turn.started` → `item.started`/`item.completed` →
 `turn.completed` (carries `usage`); failures as `turn.failed` / `error`. Parse per line.
+
+**An `error` _item_ is not a failed turn.** A perfectly healthy run emits `item.completed`
+carrying `item.type: "error"` for advisory notices (a truncated skill-description budget, say)
+and still reaches `turn.completed` with exit 0. Judge the run on `turn.completed` versus
+`turn.failed` plus the exit code; a supervisor that greps the JSONL for `error` condemns every
+clean run.
+
 `--output-schema` and `-o` compose — stdout stays JSONL, `-o` gets final text. `-C` moves
 the agent's working root but not the CLI's own path resolution: both `--output-schema` and
 `-o` are resolved against the invoking shell. Keep `-o` pointed at `$LOG`, outside the
@@ -259,10 +267,11 @@ these runs fail.
 - Every `thread/start` restarts the entire MCP server set (~20 servers with a heavy
   config). Thread creation is neither free nor fast — trim MCP for delegated work, or
   reuse threads instead of one-per-task.
-- On Linux hosts with `kernel.apparmor_restrict_unprivileged_userns=1`, the app-server
-  logs a bubblewrap/user-namespace ERROR at startup. It is a false alarm: codex falls back
-  to its own Landlock/seccomp helper. Confirm with `codex doctor`, which reports the
-  sandbox as active.
+- Older codex builds logged a bubblewrap/user-namespace ERROR at app-server startup on Linux
+  hosts with `kernel.apparmor_restrict_unprivileged_userns=1`. It was always a false alarm —
+  codex falls back to its own sandbox helper — and 0.146.0 no longer emits it (checked on such
+  a host: startup stderr was empty). If an older build still shouts, `codex doctor` settles it,
+  reporting `sandbox  restricted fs + restricted network` plus the helper path.
 - Piping `jq` output straight into `wc`/`rg` has truncated non-deterministically. Write to
   a file first when a count matters.
 - The three CLIs may already share global instructions (`~/.codex/AGENTS.md`,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -191,7 +191,15 @@ the agent's working root but not the CLI's own path resolution: both `--output-s
 worktree — an artifact written inside it leaves the tree dirty, and `git worktree remove`
 then refuses without `--force`.
 
+**Rule 6 has a purpose-built lane on the codex side.** `codex exec review --base "$BASE"`
+reviews a branch against its base headlessly and takes the same `--json` / `-o` /
+`--output-schema` plumbing as `codex exec`; `--uncommitted` and `--commit <SHA>` narrow the
+scope instead. Because it reads a diff rather than a conversation, it strips the implementer's
+self-assessment by construction. It only satisfies rule 6 when codex is the _reviewer_ — when
+codex wrote the code, the diff still goes to grok.
+
 Also useful: `--ephemeral` and `--ignore-user-config` / `--ignore-rules` for hermetic runs,
+`--strict-config` to make an unrecognized config key an error rather than a silent ignore,
 `codex exec resume --last`, `grok --worktree=<name> --worktree-ref=<base>`
 plus `grok worktree list|rm|gc`.
 
@@ -210,6 +218,15 @@ codex app-server generate-json-schema --out ./asproto
 jq -r '.oneOf[]? | .properties?.method?.enum?[0]? // empty' \
   asproto/ClientRequest.json > methods.txt
 ```
+
+That emits the stable surface only — 90 methods on 0.146.0. Add `--experimental` and roughly
+thirty more appear (remote control, realtime audio, `thread/search`, `process/*`). Read them if
+you are hunting for a capability, but do not build a supervisor on one: the flag exists
+precisely because they move without notice.
+
+`--stdio` is shorthand for `--listen stdio://`. `--listen` also takes `unix://PATH` and
+`ws://IP:PORT`, which is what you want if the supervisor and the server are not
+parent-and-child processes.
 
 What Lane B uniquely buys: `turn/steer` (inject correction mid-turn), `turn/interrupt`,
 `thread/fork` (variants off a shared prefix), `account/rateLimits/read`, and
@@ -258,7 +275,8 @@ these runs fail.
    gets it without adopting Lane B for the actual work.
 6. **Whoever writes, someone else reviews.** Each model finds more bugs in the other's
    code than its own. Give the reviewer the spec and the diff — strip the implementer's
-   own assessment, which measurably softens review depth.
+   own assessment, which measurably softens review depth. When codex is the reviewer,
+   `codex exec review` (Lane A) already works that way.
 7. **Never let an agent author `AGENTS.md`.** Human-written only; generated ones cost
    context and slightly reduce success.
 

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -160,7 +160,8 @@ nobody has reviewed it yet.
 **codex validates `--output-schema` in strict mode.** Every key in `properties` must also
 appear in `required`, and `additionalProperties` must be `false`. Omit one and the turn dies
 with `invalid_json_schema` before any work happens. The reason lands in the JSONL — once as an
-`error` event, again on `turn.failed` — and _not_ in the `.err` file, which stays empty. A
+`error` event, again on `turn.failed` — and _not_ in the `.err` file, which carries only
+startup chatter. A
 supervisor that reads only stderr sees a silent failure. Model optional fields as nullable
 types, not as absent-from-`required`.
 
@@ -222,9 +223,10 @@ identical to a crash or a bad schema path. The exit code is the only signal: 124
 SIGTERM ended it, 137 when `-k` escalated to SIGKILL (measured on GNU coreutils 9.4). Do not
 lean too hard on 137 though — an OOM kill or a CI runner reaping the job produces it too.
 Treat any non-zero code as "no usable result", then look for the reason in the JSONL first —
-`turn.failed` and `error` carry it, and a schema rejection puts it there while leaving `.err`
-empty. Fall back to `.err` only for failures that never reached the protocol at all. Either
-way the worktree still holds partial, uncommitted edits.
+`turn.failed` and `error` carry it, and a schema rejection puts it there rather than in
+`.err`. Fall back to `.err` only for failures that never reached the protocol at all — and
+do not test it for emptiness, since it collects startup chatter regardless. Either way the
+worktree still holds partial, uncommitted edits.
 
 Keep stderr in its own file. Both machine-readable outputs are parsed structurally, so
 folding diagnostics into them with `2>&1` corrupts the parse — and codex does write ordinary
@@ -260,9 +262,12 @@ Three things about it will bite on first use:
 ```bash
 # Parent-level flags go BEFORE `review` — the subcommand has no -C, -p, -s, --add-dir, -i.
 # The spec rides in positionally, which is the only shape that carries spec AND diff (2 below).
-codex exec -C "$WORKTREES/$t" review --json -o "$LOG/$t.review.txt" \
+# It is still a `codex exec` turn: no turn cap (rule 4), and --json needs its own redirect.
+"$TIMEOUT" -k 30s 30m codex exec -C "$WORKTREES/$t" review \
+  --json -o "$LOG/$t.review.txt" \
   "$(cat "$BRIEFS/$t.md")
-Review the diff of HEAD against $BASE against that spec." < /dev/null
+Review the diff of HEAD against $BASE against that spec." < /dev/null \
+  > "$LOG/$t.review.jsonl" 2> "$LOG/$t.review.err"
 
 # codex exec review -C …            → error: unexpected argument '-C' found
 # codex exec review --base X "spec" → error: the argument '--base <BRANCH>' cannot be used
@@ -400,7 +405,10 @@ these runs fail.
    — not `codex login status`, which cannot distinguish profiles and hides a `CODEX_API_KEY`
    override — plus grok's `total_cost_usd` from the previous batch. A real quota figure needs
    `account/rateLimits/read`, which is Lane B; one short app-server handshake gets it without
-   adopting Lane B for the actual work.
+   adopting Lane B for the actual work. Start that handshake with `CODEX_API_KEY` unset, as
+   `run_codex` does — the app-server lane ignores the variable, so otherwise it hands you the
+   stored login's quota while the workers bill metered API, reassuring you in exactly the case
+   that costs money.
 6. **Whoever writes, someone else reviews.** Each model finds more bugs in the other's
    code than its own. Give the reviewer the spec and the diff — strip the implementer's
    own assessment, which measurably softens review depth. When codex is the reviewer,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -63,15 +63,6 @@ git rev-parse --verify -q "$BASE" >/dev/null || { echo "base '$BASE' not found" 
 TIMEOUT=$(command -v timeout || command -v gtimeout) ||
   { echo "no GNU timeout — macOS: brew install coreutils" >&2; exit 1; }
 
-# CODEX_HOME picks which codex account the fan-out spends. Demand it rather than defaulting:
-# an inherited value silently spends the wrong profile, which is the failure this guards. And
-# CODEX_API_KEY outranks the pinned profile in this lane, so drop it. See "CODEX_HOME selects
-# the profile" below.
-export CODEX_HOME=${CODEX_HOME:?name the codex profile to spend from, e.g. $HOME/.codex}
-[ -f "$CODEX_HOME/auth.json" ] ||
-  { echo "no auth.json in $CODEX_HOME — wrong profile?" >&2; exit 1; }
-unset CODEX_API_KEY
-
 # One result contract, consumed differently: codex takes a path, grok takes the text.
 cat > "$RUN/result.schema.json" <<'JSON'
 {
@@ -87,9 +78,18 @@ cat > "$RUN/result.schema.json" <<'JSON'
 JSON
 
 run_codex() { # $1 = task id
+  # CODEX_HOME names the account this spends and no CLI flag does — but guard it inside the
+  # lane, or an all-grok fan-out dies here on a host without codex. `-u CODEX_API_KEY` closes
+  # the env override; a custom provider's own `env_key` outranks even that, so assert the
+  # account with rule 5's `codex doctor` query before going wide. See "CODEX_HOME selects the
+  # profile" below.
+  local home=${CODEX_HOME:-$HOME/.codex}
+  [ -f "$home/auth.json" ] ||
+    { echo "$1 no-codex-auth-in-$home" >> "$LOG/exit-codes"; return; }
   # codex has no turn cap, so `timeout` is the budget (rule 4). -k reaps a worker that
   # ignores SIGTERM; exit 124 means the budget fired, not that the task failed.
-  "$TIMEOUT" -k 30s 30m codex exec --json --sandbox workspace-write \
+  "$TIMEOUT" -k 30s 30m env -u CODEX_API_KEY CODEX_HOME="$home" \
+    codex exec --json --sandbox workspace-write \
     -C "$WORKTREES/$1" --output-schema "$RUN/result.schema.json" -o "$LOG/$1.last.txt" \
     "$(cat "$BRIEFS/$1.md")" < /dev/null \
     > "$LOG/$1.jsonl" 2> "$LOG/$1.err"
@@ -176,7 +176,11 @@ never credentials — even `--ignore-user-config` keeps reading auth from `CODEX
 Measured precedence in `codex exec`: a provider's own `env_key` beats **`CODEX_API_KEY`**,
 which beats the stored ChatGPT login. Export `CODEX_API_KEY` and every worker bills metered
 API from a profile whose `auth.json` still says `chatgpt` — so `unset` it, or launch through
-`env -u CODEX_API_KEY`.
+`env -u CODEX_API_KEY`. That closes one rung, not the ladder: unless you pass
+`--ignore-user-config`, a `model_provider` in `$CODEX_HOME/config.toml` can name an `env_key`
+already sitting in your environment, and by the ordering above it wins anyway. Nothing in the
+launcher can see that, which is why the pre-flight below asserts the resolved account instead
+of trusting the guard.
 
 `OPENAI_API_KEY` is _not_ that variable, which is worth knowing precisely because it looks
 like it should be. On 0.146.0 the built-in `openai` provider sets no `env_key`, so exporting
@@ -209,8 +213,8 @@ empty. Fall back to `.err` only for failures that never reached the protocol at 
 way the worktree still holds partial, uncommitted edits.
 
 Keep stderr in its own file. Both machine-readable outputs are parsed structurally, so
-folding diagnostics into them with `2>&1` corrupts the parse — including the harmless
-startup ERROR described under Gotchas.
+folding diagnostics into them with `2>&1` corrupts the parse — and codex does write ordinary
+chatter there, `Reading additional input from stdin...` on every redirected run for one.
 
 `< /dev/null` is mandatory. With non-TTY stdin, codex appends whatever it finds as a
 `<stdin>` block on your prompt; a spawned shell inherits stdin, so omitting it silently
@@ -241,8 +245,14 @@ Three things about it will bite on first use:
 
 ```bash
 # Parent-level flags go BEFORE `review` — the subcommand has no -C, -p, -s, --add-dir, -i.
-codex exec -C "$WORKTREES/$t" review --base "$BASE" --json -o "$LOG/$t.review.txt"
-# codex exec review -C … → error: unexpected argument '-C' found
+# The spec rides in positionally, which is the only shape that carries spec AND diff (2 below).
+codex exec -C "$WORKTREES/$t" review --json -o "$LOG/$t.review.txt" \
+  "$(cat "$BRIEFS/$t.md")
+Review the diff of HEAD against $BASE against that spec." < /dev/null
+
+# codex exec review -C …            → error: unexpected argument '-C' found
+# codex exec review --base X "spec" → error: the argument '--base <BRANCH>' cannot be used
+#                                     with '[PROMPT]'
 ```
 
 1. **The target and a prompt are mutually exclusive.** `--base`, `--uncommitted`, `--commit`,
@@ -251,7 +261,7 @@ codex exec -C "$WORKTREES/$t" review --base "$BASE" --json -o "$LOG/$t.review.tx
    ordering will not save you, and `-` reads as a prompt, so stdin is not a way around it.
 2. **So `--base` cannot carry the spec** that rule 6 asks for. Use the prompt form instead and
    let the reviewer resolve the diff itself — `codex exec -C "$WORKTREES/$t" review "<spec>.
-   Review the diff of HEAD against $BASE."` A repo `AGENTS.md` also reaches the review turn
+Review the diff of HEAD against $BASE."` A repo `AGENTS.md` also reaches the review turn
    (verified in its rollout), but that is the human-written channel of rule 7, not somewhere
    a supervisor writes a per-task spec.
 3. **A `--base` that does not resolve fails quietly**, unlike the script's own `rev-parse`
@@ -334,7 +344,7 @@ assuming N× throughput.
   session spends subscription quota, but an API key — stored via `codex login --with-api-key`
   or exported as `CODEX_API_KEY`, which outranks the stored login — bills metered usage, so
   the same fan-out becomes cash. `codex doctor`'s `auth mode` row tells you which; `codex
-  login status` does not.
+login status` does not.
 - **grok** — bounded mechanical breadth: tests, repetitive multi-file edits, exploration.
   `--max-turns` gives a hard budget, and its JSON reports `total_cost_usd`. Metered, so
   watch the number.

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -119,11 +119,11 @@ for spec in "${TASKS[@]}"; do
     codex | grok) ;;
     *) echo "$t bad-lane-$lane" >> "$LOG/exit-codes"; continue ;;
   esac
-  # Only codex tasks need the account, so an all-grok fan-out runs fine without codex. This
-  # deliberately demands a stored login: `run_codex` strips CODEX_API_KEY, so on a host where
-  # that variable IS the credential (CI, typically), drop the `env -u` and accept metered
-  # billing — do not just create an empty auth.json.
-  if [ "$lane" = codex ] && [ ! -f "$CODEX_HOME/auth.json" ]; then
+  # Only codex tasks need the account, so an all-grok fan-out runs fine without codex. Accept
+  # either credential: a stored login, or CODEX_API_KEY where that IS the credential (CI,
+  # typically) — in which case also drop `run_codex`'s `env -u`, and accept that the two then
+  # bill differently. Never paper over a missing account by creating an empty auth.json.
+  if [ "$lane" = codex ] && [ ! -f "$CODEX_HOME/auth.json" ] && [ -z "$CODEX_API_KEY" ]; then
     echo "$t no-codex-auth-in-$CODEX_HOME" >> "$LOG/exit-codes"; continue
   fi
   # Never launch a worker into a tree you failed to create — on a re-run the add fails
@@ -210,7 +210,9 @@ actually spends; `reachability mode` describes only the probe, and `auth env var
 reports presence, never precedence:
 
 ```bash
-codex doctor --json | jq -r '.checks[]|select(.id=="network.websocket_reachability").details["auth mode"]'
+# Mirror `run_codex`'s `env -u`, or you measure your own credential rather than the workers'.
+env -u CODEX_API_KEY codex doctor --json |
+  jq -r '.checks[]|select(.id=="network.websocket_reachability").details["auth mode"]'
 ```
 
 Scope that to Lane A. On this build the app-server lane ignored `CODEX_API_KEY` and spent the


### PR DESCRIPTION
Re-verified `skills/orchestrate-agents/SKILL.md` against the currently installed
`codex-cli 0.146.0` and `grok 0.2.118`. Nothing in the skill was broken, but three
documented claims turned out to be wrong in ways that would mislead a supervisor mid-run,
and one gap could send a fan-out to the wrong billing account.

## Corrections

**Schema-rejection diagnostics pointed at the wrong file.** The skill said the stderr file
explains an `invalid_json_schema` rejection. It doesn't — `.err` stays empty; the reason
arrives on stdout, once as an `error` event and again on `turn.failed`. A supervisor
following the old advice sees a silent failure.

**An `error` *item* was conflated with a failed turn.** A healthy run emits `item.completed`
carrying `item.type: "error"` for advisory notices and still reaches `turn.completed` with
exit 0. Any supervisor grepping the JSONL for `error` would condemn every clean run. The
real signal is `turn.completed` vs `turn.failed` plus the exit code.

**The apparmor/bubblewrap gotcha is stale.** 0.146.0 emits no such ERROR at app-server
startup on a host with `kernel.apparmor_restrict_unprivileged_userns=1` (checked: startup
stderr was empty). Reframed as historical, with `codex doctor`'s current output wording.

**Rule 5's budget pre-flight was unreliable.** `codex login status` prints an identical
`Logged in using ChatGPT` for every profile directory and says nothing about an
`OPENAI_API_KEY` in the environment overriding a stored ChatGPT login — so it can report
"subscription" immediately before a fan-out that bills metered API. Rule 5 and the codex
bullet now point at `codex doctor`, which warns `mixed auth signals` and breaks out
`auth env vars present` / `stored auth mode` / `reachability mode`.

## Additions

- **`CODEX_HOME` is the only account selector**, with the trap named: `-p/--profile` layers
  `$CODEX_HOME/<name>.config.toml`, so it switches config and never credentials. The Lane A
  script now exports it (defaulted, so single-profile machines are unaffected) since workers
  inherit the supervisor's environment.
- **`codex exec review`** — a headless review lane taking the same `--json` / `-o` /
  `--output-schema` plumbing, wired to non-negotiable 6 with the caveat that it only
  satisfies the rule when codex is the reviewer.
- **Lane B**: one server is one profile (auth binds from the process's `CODEX_HOME`), and
  `initialize` echoes `codexHome` back so you can assert which one you attached to.
- Protocol-dump caveat — the default emits the 90-method stable surface and hides ~30
  experimental ones; `--stdio` is shorthand for `--listen stdio://`, which also takes
  `unix://` and `ws://`. Plus `--strict-config`.

## Verification

Claims were checked by running the binaries, not by reading `--help`:

- `codex exec` end-to-end with a strict schema — confirmed the event sequence, `usage` on
  `turn.completed`, and that `-C` does not move path resolution for `--output-schema` / `-o`.
- A deliberately loose schema — confirmed `invalid_json_schema` and where the reason lands.
- A live `app-server` handshake — `initialize` → `initialized` → `account/rateLimits/read`,
  confirming the absent `jsonrpc` field and every Lane B method the skill names.
- `codex login status` and `codex doctor` across multiple `CODEX_HOME` values, with and
  without `OPENAI_API_KEY`.

Everything else in the skill was checked and left alone.

## Notes for review

- The branch was renamed from the harness default (`claude/…`) to satisfy the repo's
  `branch-rules` ruleset, which rejects any prefix outside the conventional-commit types.
- No local paths or profile names are in the diff — this repo is public.
- `pnpm lint` aborts with an out-of-memory error in my environment before reaching any file,
  which is pre-existing and unrelated to a markdown-only change. `prettier --check` passes
  across `skills/**/*.md`, and the pre-commit hook passed on each commit.
