### PR TITLE
fix(deps): patch brace-expansion DoS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -716,7 +716,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -915,7 +915,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary

- Upgrade the transitive `brace-expansion` resolution from 5.0.6 to 5.0.9.
- Remediate CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp reported by Dependabot alert #12.
- Keep the change scoped to `pnpm-lock.yaml`; no top-level dependency versions change.

## Validation

- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
- `pnpm install --frozen-lockfile`
- `pnpm audit` — no known vulnerabilities
- `pnpm exec prettier --check pnpm-lock.yaml`
- `pnpm lint` — existing Prettier failures remain in two files unchanged from `origin/main`:
  - `skills/video-generation/references/volcengine-api.md`
  - `skills/video-generation/SKILL.md`