### PR TITLE
feat: add usage-aware agent routing

### DIFF
--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -3,9 +3,10 @@ name: orchestrate-agents
 description: >-
   Orchestrate codex and grok CLIs as parallel workers from a supervising agent session.
   Use when work should be delegated across isolated worktrees, run concurrently, or
-  cross-reviewed by another model. Covers lane selection, decomposition, durable state,
-  budgets, cleanup, verification, and serialized integration. Do not use for in-process
-  subagents or a single sequential task.
+  cross-reviewed by another model, including fleets of codex app-servers backed by multiple
+  CODEX_HOME profiles. Covers usage-aware routing, lane selection, decomposition, durable
+  state, budgets, cleanup, verification, and serialized integration. Do not use for
+  in-process subagents or a single sequential task.
 ---
 
 # Orchestrate agents: codex + grok
@@ -28,11 +29,42 @@ file scopes collide, or no independent work remains.
 Use Lane A by default. Use Lane B when mid-turn correction, thread reuse, programmatic
 approvals, or rate-limit inspection justifies the extra protocol and lifecycle complexity.
 
+## Route by observed capacity
+
+Maintain an explicit server-to-`CODEX_HOME` inventory. Before fan-out, periodically while the
+fleet runs, and after worker completion or a rate-limit response, run
+`scripts/read-codex-usage.py` for every profile and persist its JSON Lines output with the fleet
+state. It derives the newest `token_count.rate_limits` event across each profile's session logs
+and verifies that `codex login status` reports ChatGPT authentication. Pass one
+`--home PROFILE=CODEX_HOME` per server and set `--max-age` to the fleet's freshness tolerance.
+Consume `status`, `schedulable`, `snapshot_age_seconds`, `effective_remaining_percent`, and the
+raw `rate_limits`; one bad profile remains a data record rather than aborting the sample round.
+
+Treat this as an observed snapshot, not a live billing query. Session logs refresh only when
+Codex emits a usage event. Never describe a stale or post-reset snapshot as current; use a real,
+low-cost probe only when a dispatch decision warrants fresher evidence.
+
+Route work from the normalized snapshot and in-flight reservations:
+
+- Exclude profiles with invalid authentication, missing or stale evidence, a reached limit, or
+  spend control. Treat credits as supplemental capacity, not as a substitute for window quota.
+- Use the lowest remaining percentage across reported windows as effective headroom. Reserve
+  expected usage for running and queued work so simultaneous dispatches do not all consume the
+  same apparent capacity.
+- Estimate task cost and uncertainty from prior deltas. Prefer the smallest eligible capacity
+  that still leaves the configured reserve, preserving room for expensive or unpredictable work.
+- When no profile safely fits, reduce concurrency or wait for the earliest relevant reset. Do not
+  evade a limit by changing identity outside the declared profile inventory.
+
+Choose a sampling cadence that matches task duration and decision frequency; polling the same
+files more often does not make their underlying snapshot fresher.
+
 ## Run the fleet
 
 1. **Preflight.** Read repository instructions, resolve the upstream base, check host capacity,
    identify runtime and dependency collisions, and verify the credential and quota each worker
-   will actually spend. Do not infer billing from a profile name or login-status message.
+   will actually spend. Use login status only to establish auth mode; obtain capacity from the
+   matching profile's usage snapshot.
 2. **Decompose.** Give each concurrent task one worker, one worktree, one branch, one brief, and
    a non-overlapping file scope. Serialize dependency changes, migrations, protocol changes, and
    any other shared boundary; land those before dependent work.
@@ -43,8 +75,9 @@ approvals, or rate-limit inspection justifies the extra protocol and lifecycle c
    visible background tasks unless they must outlive the supervisor session. Close inherited
    stdin and keep structured output, final output, and stderr separate.
 5. **Persist state.** Store every round's brief, structured result, exit code, logs, branch, and
-   worktree on disk. Reconstruct fleet state from those artifacts and live processes after every
-   checkpoint; never depend on conversation memory.
+   worktree on disk, together with usage observations and capacity reservations. Reconstruct
+   fleet state from those artifacts and live processes after every checkpoint; never depend on
+   conversation memory.
 6. **Monitor.** Judge completion from the process exit status and structured terminal state, not
    from the presence of output or the word `error`. Preserve partial worktrees for inspection.
 7. **Review.** Give a different model the brief and diff without the implementer's assessment.

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -35,10 +35,11 @@ Maintain an explicit server-to-`CODEX_HOME` inventory. Before fan-out, periodica
 fleet runs, and after worker completion or a rate-limit response, run
 `scripts/read-codex-usage.py` for every profile and persist its JSON Lines output with the fleet
 state. It derives the newest `token_count.rate_limits` event across each profile's session logs
-and verifies that `codex login status` reports ChatGPT authentication. Pass one
-`--home PROFILE=CODEX_HOME` per server and set `--max-age` to the fleet's freshness tolerance.
-Consume `status`, `schedulable`, `snapshot_age_seconds`, `effective_remaining_percent`, and the
-raw `rate_limits`; one bad profile remains a data record rather than aborting the sample round.
+changed within the freshness window, or a stale fallback when none exists, and verifies that
+`codex login status` reports ChatGPT authentication. Pass one `--home PROFILE=CODEX_HOME` per
+server and set `--max-age` to the fleet's freshness tolerance. Consume `status`, `schedulable`,
+`snapshot_age_seconds`, `effective_remaining_percent`, and the raw `rate_limits`; one bad profile
+remains a data record rather than aborting the sample round.
 
 Treat this as an observed snapshot, not a live billing query. Session logs refresh only when
 Codex emits a usage event. Never describe a stale or post-reset snapshot as current; use a real,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -35,11 +35,12 @@ Maintain an explicit server-to-`CODEX_HOME` inventory. Before fan-out, periodica
 fleet runs, and after worker completion or a rate-limit response, run
 `scripts/read-codex-usage.py` for every profile and persist its JSON Lines output with the fleet
 state. It derives the newest `token_count.rate_limits` event across each profile's session logs
-by reading backward only to each file's latest matching event, and verifies that
-`codex login status` reports ChatGPT authentication. Pass one `--home PROFILE=CODEX_HOME` per
-server and set `--max-age` to the fleet's freshness tolerance. Consume `status`, `schedulable`,
-`snapshot_age_seconds`, `effective_remaining_percent`, and the raw `rate_limits`; one bad profile
-remains a data record rather than aborting the sample round.
+by comparing events in files changed within the freshness window, falling back to older logs only
+when no recent snapshot exists, and verifies that `codex login status` reports ChatGPT
+authentication. Pass one `--home PROFILE=CODEX_HOME` per server and set `--max-age` to the fleet's
+freshness tolerance. Consume `status`, `schedulable`, `snapshot_age_seconds`,
+`effective_remaining_percent`, and the raw `rate_limits`; one bad profile remains a data record
+rather than aborting the sample round.
 
 Treat this as an observed snapshot, not a live billing query. Session logs refresh only when
 Codex emits a usage event. Never describe a stale or post-reset snapshot as current; use a real,

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -35,7 +35,7 @@ Maintain an explicit server-to-`CODEX_HOME` inventory. Before fan-out, periodica
 fleet runs, and after worker completion or a rate-limit response, run
 `scripts/read-codex-usage.py` for every profile and persist its JSON Lines output with the fleet
 state. It derives the newest `token_count.rate_limits` event across each profile's session logs
-changed within the freshness window, or a stale fallback when none exists, and verifies that
+by reading backward only to each file's latest matching event, and verifies that
 `codex login status` reports ChatGPT authentication. Pass one `--home PROFILE=CODEX_HOME` per
 server and set `--max-age` to the fleet's freshness tolerance. Consume `status`, `schedulable`,
 `snapshot_age_seconds`, `effective_remaining_percent`, and the raw `rate_limits`; one bad profile

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -36,7 +36,7 @@ fleet runs, and after worker completion or a rate-limit response, run
 `scripts/read-codex-usage.py` for every profile and persist its JSON Lines output with the fleet
 state. It derives the newest `token_count.rate_limits` event across each profile's session logs
 by comparing events in files changed within the freshness window, falling back to older logs only
-when no recent snapshot exists, and verifies that `codex login status` reports ChatGPT
+as stale diagnostic evidence, and verifies that `codex login status` reports ChatGPT
 authentication. Pass one `--home PROFILE=CODEX_HOME` per server and set `--max-age` to the fleet's
 freshness tolerance. Consume `status`, `schedulable`, `snapshot_age_seconds`,
 `effective_remaining_percent`, and the raw `rate_limits`; one bad profile remains a data record

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -27,22 +27,12 @@ def parse_timestamp(value: Any) -> float | None:
 
 def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:
     try:
-        session_files = sorted(
-            (
-                (path.stat().st_mtime, path)
-                for path in sessions_dir.rglob("*.jsonl")
-                if path.is_file()
-            ),
-            reverse=True,
-        )
+        session_files = list(sessions_dir.rglob("*.jsonl"))
     except OSError:
         return None
 
     latest: tuple[float, dict[str, Any], Path] | None = None
-    for modified_at, path in session_files:
-        if latest is not None and modified_at <= latest[0]:
-            break
-
+    for path in session_files:
         try:
             with path.open(encoding="utf-8") as session:
                 for line in session:
@@ -119,6 +109,11 @@ def sample_profile(
         "login_mode": mode,
         "status": "no_snapshot",
         "schedulable": False,
+        "snapshot_at": None,
+        "snapshot_age_seconds": None,
+        "session_path": None,
+        "effective_remaining_percent": None,
+        "rate_limits": None,
     }
 
     snapshot = latest_rate_limits(codex_home / "sessions")
@@ -131,6 +126,7 @@ def sample_profile(
     event, session_path = snapshot
     observed_at = parse_timestamp(event.get("timestamp"))
     if observed_at is None:
+        record["status"] = "invalid_snapshot"
         return record
 
     rate_limits = event["payload"]["rate_limits"]

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -237,7 +237,7 @@ def sample_profile(
         status = "invalid_snapshot"
     elif stale:
         status = "stale"
-    elif limit_reached or spend_control:
+    elif limit_reached or spend_control or min(remaining) <= 0:
         status = "exhausted"
 
     record.update(

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -85,19 +85,40 @@ def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
     return latest
 
 
-def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:
+def latest_rate_limits(
+    sessions_dir: Path, not_before: float
+) -> tuple[dict[str, Any], Path] | None:
+    session_files: list[tuple[float, Path]] = []
     try:
-        session_files = list(sessions_dir.rglob("*.jsonl"))
+        for path in sessions_dir.rglob("*.jsonl"):
+            try:
+                metadata = path.stat()
+            except OSError:
+                continue
+            session_files.append((max(metadata.st_mtime, metadata.st_ctime), path))
     except OSError:
         return None
+    session_files.sort(reverse=True)
 
     latest: tuple[float, dict[str, Any], Path] | None = None
-    for path in session_files:
+    older_start = len(session_files)
+    for index, (changed_at, path) in enumerate(session_files):
+        if changed_at < not_before:
+            older_start = index
+            break
         candidate = latest_in_file(path)
         if candidate is not None and (latest is None or candidate[0] > latest[0]):
             latest = candidate
 
-    return None if latest is None else (latest[1], latest[2])
+    if latest is not None:
+        return latest[1], latest[2]
+
+    for _, path in session_files[older_start:]:
+        candidate = latest_in_file(path)
+        if candidate is not None:
+            return candidate[1], candidate[2]
+
+    return None
 
 
 def login_mode(codex_home: Path, codex: str) -> str:
@@ -118,7 +139,10 @@ def login_mode(codex_home: Path, codex: str) -> str:
     if result.returncode != 0:
         return "unavailable"
     status_lines = [
-        line.strip().casefold() for line in result.stdout.splitlines() if line.strip()
+        line.strip().casefold()
+        for output in (result.stdout, result.stderr)
+        for line in output.splitlines()
+        if line.strip()
     ]
     if any(line.startswith("logged in using chatgpt") for line in status_lines):
         return "chatgpt"
@@ -141,7 +165,8 @@ def sample_profile(
     max_age: int,
 ) -> dict[str, Any]:
     mode = login_mode(codex_home, codex)
-    snapshot = latest_rate_limits(codex_home / "sessions")
+    scan_started_at = datetime.now(timezone.utc).timestamp()
+    snapshot = latest_rate_limits(codex_home / "sessions", scan_started_at - max_age)
     sampled_at = datetime.now(timezone.utc).timestamp()
     record: dict[str, Any] = {
         "profile": profile,

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import subprocess
 import sys
@@ -14,10 +15,19 @@ from typing import Any
 
 
 def parse_timestamp(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
     if isinstance(value, (int, float)):
-        return float(value)
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
     if not isinstance(value, str):
         return None
+
+    try:
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+    except ValueError:
+        pass
 
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
@@ -25,43 +35,70 @@ def parse_timestamp(value: Any) -> float | None:
         return None
 
 
-def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:
+def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
+    latest: tuple[float, dict[str, Any], Path] | None = None
     try:
-        session_files = list(sessions_dir.rglob("*.jsonl"))
+        with path.open(encoding="utf-8", errors="replace") as session:
+            for line in session:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+
+                payload = event.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("type") != "token_count" or not isinstance(
+                    payload.get("rate_limits"), dict
+                ):
+                    continue
+
+                observed_at = parse_timestamp(event.get("timestamp"))
+                if observed_at is None:
+                    continue
+                if latest is None or observed_at > latest[0]:
+                    latest = (observed_at, event, path)
     except OSError:
         return None
+    return latest
+
+
+def latest_rate_limits(
+    sessions_dir: Path, not_before: float
+) -> tuple[dict[str, Any], Path] | None:
+    session_files: list[tuple[float, Path]] = []
+    try:
+        for path in sessions_dir.rglob("*.jsonl"):
+            try:
+                metadata = path.stat()
+            except OSError:
+                continue
+            session_files.append((max(metadata.st_mtime, metadata.st_ctime), path))
+    except OSError:
+        return None
+    session_files.sort(reverse=True)
 
     latest: tuple[float, dict[str, Any], Path] | None = None
-    for path in session_files:
-        try:
-            with path.open(encoding="utf-8", errors="replace") as session:
-                for line in session:
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if not isinstance(event, dict):
-                        continue
+    older_start = len(session_files)
+    for index, (changed_at, path) in enumerate(session_files):
+        if changed_at < not_before:
+            older_start = index
+            break
+        candidate = latest_in_file(path)
+        if candidate is not None and (latest is None or candidate[0] > latest[0]):
+            latest = candidate
 
-                    payload = event.get("payload")
-                    if not isinstance(payload, dict):
-                        continue
-                    if payload.get("type") != "token_count" or not isinstance(
-                        payload.get("rate_limits"), dict
-                    ):
-                        continue
+    if latest is not None:
+        return latest[1], latest[2]
 
-                    observed_at = parse_timestamp(event.get("timestamp"))
-                    if observed_at is None:
-                        continue
-                    if latest is None or observed_at > latest[0]:
-                        latest = (observed_at, event, path)
-        except OSError:
-            continue
+    for _, path in session_files[older_start:]:
+        candidate = latest_in_file(path)
+        if candidate is not None:
+            return candidate[1], candidate[2]
 
-    if latest is None:
-        return None
-    return latest[1], latest[2]
+    return None
 
 
 def login_mode(codex_home: Path, codex: str) -> str:
@@ -79,17 +116,21 @@ def login_mode(codex_home: Path, codex: str) -> str:
     except (OSError, subprocess.TimeoutExpired):
         return "unavailable"
 
-    status_text = f"{result.stdout}\n{result.stderr}"
     if result.returncode != 0:
         return "unavailable"
-    return "chatgpt" if "chatgpt" in status_text.lower() else "other"
+    status_lines = [
+        line.strip().casefold() for line in result.stdout.splitlines() if line.strip()
+    ]
+    if not status_lines:
+        return "unavailable"
+    return "chatgpt" if status_lines[0] == "logged in using chatgpt" else "other"
 
 
 def remaining_percent(window: Any) -> float | None:
     if not isinstance(window, dict):
         return None
     used = window.get("used_percent")
-    if not isinstance(used, (int, float)):
+    if isinstance(used, bool) or not isinstance(used, (int, float)):
         return None
     return max(0.0, min(100.0, 100.0 - float(used)))
 
@@ -101,7 +142,8 @@ def sample_profile(
     max_age: int,
 ) -> dict[str, Any]:
     mode = login_mode(codex_home, codex)
-    snapshot = latest_rate_limits(codex_home / "sessions")
+    scan_started_at = datetime.now(timezone.utc).timestamp()
+    snapshot = latest_rate_limits(codex_home / "sessions", scan_started_at - max_age)
     sampled_at = datetime.now(timezone.utc).timestamp()
     record: dict[str, Any] = {
         "profile": profile,
@@ -132,13 +174,27 @@ def sample_profile(
     rate_limits = event["payload"]["rate_limits"]
     windows = [rate_limits.get("primary"), rate_limits.get("secondary")]
     remaining = [value for value in map(remaining_percent, windows) if value is not None]
-    reset_times = [
-        window.get("resets_at")
-        for window in windows
-        if isinstance(window, dict) and isinstance(window.get("resets_at"), (int, float))
-    ]
+    reset_times: list[float] = []
+    invalid_reset = False
+    for window in windows:
+        if not isinstance(window, dict):
+            continue
+        reset_at = parse_timestamp(window.get("resets_at"))
+        if reset_at is None:
+            resets_in = window.get("resets_in_seconds")
+            if not isinstance(resets_in, bool):
+                try:
+                    relative_reset = float(resets_in)
+                except (TypeError, ValueError):
+                    relative_reset = math.nan
+                if math.isfinite(relative_reset) and relative_reset >= 0:
+                    reset_at = observed_at + relative_reset
+        if reset_at is None:
+            invalid_reset = True
+        else:
+            reset_times.append(reset_at)
     age_seconds = max(0, int(sampled_at - observed_at))
-    reset_elapsed = any(float(reset_at) <= sampled_at for reset_at in reset_times)
+    reset_elapsed = any(reset_at <= sampled_at for reset_at in reset_times)
     stale = age_seconds > max_age or reset_elapsed
     limit_reached = rate_limits.get("rate_limit_reached_type") is not None
     spend_control = bool(rate_limits.get("spend_control_reached"))
@@ -148,7 +204,7 @@ def sample_profile(
         status = "auth_error"
     elif mode != "chatgpt":
         status = "not_chatgpt"
-    elif not remaining:
+    elif not remaining or invalid_reset:
         status = "invalid_snapshot"
     elif stale:
         status = "stale"

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -9,6 +9,7 @@ import math
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -30,75 +31,72 @@ def parse_timestamp(value: Any) -> float | None:
         pass
 
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        parsed_datetime = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed_datetime.tzinfo is None:
+        return None
+    return parsed_datetime.timestamp()
+
+
+def reverse_lines(path: Path, chunk_size: int = 65536) -> Iterator[bytes]:
+    with path.open("rb") as session:
+        session.seek(0, os.SEEK_END)
+        position = session.tell()
+        remainder = b""
+        while position > 0:
+            read_size = min(chunk_size, position)
+            position -= read_size
+            session.seek(position)
+            remainder = session.read(read_size) + remainder
+            lines = remainder.split(b"\n")
+            remainder = lines[0]
+            for line in reversed(lines[1:]):
+                if line:
+                    yield line
+        if remainder:
+            yield remainder
 
 
 def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
-    latest: tuple[float, dict[str, Any], Path] | None = None
     try:
-        with path.open(encoding="utf-8", errors="replace") as session:
-            for line in session:
-                try:
-                    event = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(event, dict):
-                    continue
-
-                payload = event.get("payload")
-                if not isinstance(payload, dict):
-                    continue
-                if payload.get("type") != "token_count" or not isinstance(
-                    payload.get("rate_limits"), dict
-                ):
-                    continue
-
-                observed_at = parse_timestamp(event.get("timestamp"))
-                if observed_at is None:
-                    continue
-                if latest is None or observed_at > latest[0]:
-                    latest = (observed_at, event, path)
-    except OSError:
-        return None
-    return latest
-
-
-def latest_rate_limits(
-    sessions_dir: Path, not_before: float
-) -> tuple[dict[str, Any], Path] | None:
-    session_files: list[tuple[float, Path]] = []
-    try:
-        for path in sessions_dir.rglob("*.jsonl"):
+        for raw_line in reverse_lines(path):
             try:
-                metadata = path.stat()
-            except OSError:
+                event = json.loads(raw_line.decode("utf-8", errors="replace"))
+            except json.JSONDecodeError:
                 continue
-            session_files.append((max(metadata.st_mtime, metadata.st_ctime), path))
+            if not isinstance(event, dict):
+                continue
+
+            payload = event.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("type") != "token_count" or not isinstance(
+                payload.get("rate_limits"), dict
+            ):
+                continue
+
+            observed_at = parse_timestamp(event.get("timestamp"))
+            if observed_at is not None:
+                return observed_at, event, path
     except OSError:
         return None
-    session_files.sort(reverse=True)
+    return None
+
+
+def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:
+    try:
+        session_files = list(sessions_dir.rglob("*.jsonl"))
+    except OSError:
+        return None
 
     latest: tuple[float, dict[str, Any], Path] | None = None
-    older_start = len(session_files)
-    for index, (changed_at, path) in enumerate(session_files):
-        if changed_at < not_before:
-            older_start = index
-            break
+    for path in session_files:
         candidate = latest_in_file(path)
         if candidate is not None and (latest is None or candidate[0] > latest[0]):
             latest = candidate
 
-    if latest is not None:
-        return latest[1], latest[2]
-
-    for _, path in session_files[older_start:]:
-        candidate = latest_in_file(path)
-        if candidate is not None:
-            return candidate[1], candidate[2]
-
-    return None
+    return None if latest is None else (latest[1], latest[2])
 
 
 def login_mode(codex_home: Path, codex: str) -> str:
@@ -121,9 +119,9 @@ def login_mode(codex_home: Path, codex: str) -> str:
     status_lines = [
         line.strip().casefold() for line in result.stdout.splitlines() if line.strip()
     ]
-    if not status_lines:
-        return "unavailable"
-    return "chatgpt" if status_lines[0] == "logged in using chatgpt" else "other"
+    if any(line.startswith("logged in using chatgpt") for line in status_lines):
+        return "chatgpt"
+    return "other" if status_lines else "unavailable"
 
 
 def remaining_percent(window: Any) -> float | None:
@@ -142,8 +140,7 @@ def sample_profile(
     max_age: int,
 ) -> dict[str, Any]:
     mode = login_mode(codex_home, codex)
-    scan_started_at = datetime.now(timezone.utc).timestamp()
-    snapshot = latest_rate_limits(codex_home / "sessions", scan_started_at - max_age)
+    snapshot = latest_rate_limits(codex_home / "sessions")
     sampled_at = datetime.now(timezone.utc).timestamp()
     record: dict[str, Any] = {
         "profile": profile,
@@ -173,12 +170,14 @@ def sample_profile(
 
     rate_limits = event["payload"]["rate_limits"]
     windows = [rate_limits.get("primary"), rate_limits.get("secondary")]
-    remaining = [value for value in map(remaining_percent, windows) if value is not None]
+    remaining: list[float] = []
     reset_times: list[float] = []
     invalid_reset = False
     for window in windows:
-        if not isinstance(window, dict):
+        window_remaining = remaining_percent(window)
+        if not isinstance(window, dict) or window_remaining is None:
             continue
+        remaining.append(window_remaining)
         reset_at = parse_timestamp(window.get("resets_at"))
         if reset_at is None:
             resets_in = window.get("resets_in_seconds")
@@ -193,9 +192,10 @@ def sample_profile(
             invalid_reset = True
         else:
             reset_times.append(reset_at)
-    age_seconds = max(0, int(sampled_at - observed_at))
+    clock_skew_seconds = observed_at - sampled_at
+    age_seconds = max(0, int(-clock_skew_seconds))
     reset_elapsed = any(reset_at <= sampled_at for reset_at in reset_times)
-    stale = age_seconds > max_age or reset_elapsed
+    stale = age_seconds > max_age or reset_elapsed or clock_skew_seconds > 60
     limit_reached = rate_limits.get("rate_limit_reached_type") is not None
     spend_control = bool(rate_limits.get("spend_control_reached"))
 

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -172,7 +172,6 @@ def sample_profile(
     windows = [rate_limits.get("primary"), rate_limits.get("secondary")]
     remaining: list[float] = []
     reset_times: list[float] = []
-    invalid_reset = False
     for window in windows:
         window_remaining = remaining_percent(window)
         if not isinstance(window, dict) or window_remaining is None:
@@ -188,9 +187,7 @@ def sample_profile(
                     relative_reset = math.nan
                 if math.isfinite(relative_reset) and relative_reset >= 0:
                     reset_at = observed_at + relative_reset
-        if reset_at is None:
-            invalid_reset = True
-        else:
+        if reset_at is not None:
             reset_times.append(reset_at)
     clock_skew_seconds = observed_at - sampled_at
     age_seconds = max(0, int(-clock_skew_seconds))
@@ -204,7 +201,7 @@ def sample_profile(
         status = "auth_error"
     elif mode != "chatgpt":
         status = "not_chatgpt"
-    elif not remaining or invalid_reset:
+    elif not remaining:
         status = "invalid_snapshot"
     elif stale:
         status = "stale"

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -201,9 +201,13 @@ def sample_profile(
     windows = [rate_limits.get("primary"), rate_limits.get("secondary")]
     remaining: list[float] = []
     reset_times: list[float] = []
+    malformed_window = False
     for window in windows:
+        if window is None:
+            continue
         window_remaining = remaining_percent(window)
-        if not isinstance(window, dict) or window_remaining is None:
+        if window_remaining is None:
+            malformed_window = True
             continue
         remaining.append(window_remaining)
         reset_at = parse_timestamp(window.get("resets_at"))
@@ -235,7 +239,7 @@ def sample_profile(
         status = "auth_error"
     elif mode != "chatgpt":
         status = "not_chatgpt"
-    elif not remaining:
+    elif not remaining or malformed_window:
         status = "invalid_snapshot"
     elif stale:
         status = "stale"

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Read the newest Codex rate-limit snapshot from one or more CODEX_HOME profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def parse_timestamp(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:
+    try:
+        session_files = sorted(
+            (
+                (path.stat().st_mtime, path)
+                for path in sessions_dir.rglob("*.jsonl")
+                if path.is_file()
+            ),
+            reverse=True,
+        )
+    except OSError:
+        return None
+
+    latest: tuple[float, dict[str, Any], Path] | None = None
+    for modified_at, path in session_files:
+        if latest is not None and modified_at <= latest[0]:
+            break
+
+        try:
+            with path.open(encoding="utf-8") as session:
+                for line in session:
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+
+                    payload = event.get("payload")
+                    if not isinstance(payload, dict):
+                        continue
+                    if payload.get("type") != "token_count" or not isinstance(
+                        payload.get("rate_limits"), dict
+                    ):
+                        continue
+
+                    observed_at = parse_timestamp(event.get("timestamp"))
+                    if observed_at is None:
+                        continue
+                    if latest is None or observed_at > latest[0]:
+                        latest = (observed_at, event, path)
+        except OSError:
+            continue
+
+    if latest is None:
+        return None
+    return latest[1], latest[2]
+
+
+def login_mode(codex_home: Path, codex: str) -> str:
+    environment = os.environ.copy()
+    environment["CODEX_HOME"] = str(codex_home)
+    try:
+        result = subprocess.run(
+            [codex, "login", "status"],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unavailable"
+
+    status_text = f"{result.stdout}\n{result.stderr}"
+    if result.returncode != 0:
+        return "unavailable"
+    return "chatgpt" if "chatgpt" in status_text.lower() else "other"
+
+
+def remaining_percent(window: Any) -> float | None:
+    if not isinstance(window, dict):
+        return None
+    used = window.get("used_percent")
+    if not isinstance(used, (int, float)):
+        return None
+    return max(0.0, min(100.0, 100.0 - float(used)))
+
+
+def sample_profile(
+    profile: str,
+    codex_home: Path,
+    codex: str,
+    max_age: int,
+    sampled_at: float,
+) -> dict[str, Any]:
+    mode = login_mode(codex_home, codex)
+    record: dict[str, Any] = {
+        "profile": profile,
+        "codex_home": str(codex_home),
+        "sampled_at": datetime.fromtimestamp(sampled_at, timezone.utc).isoformat(),
+        "login_mode": mode,
+        "status": "no_snapshot",
+        "schedulable": False,
+    }
+
+    snapshot = latest_rate_limits(codex_home / "sessions")
+    if snapshot is None:
+        record["status"] = "auth_error" if mode == "unavailable" else "no_snapshot"
+        if mode == "other":
+            record["status"] = "not_chatgpt"
+        return record
+
+    event, session_path = snapshot
+    observed_at = parse_timestamp(event.get("timestamp"))
+    if observed_at is None:
+        return record
+
+    rate_limits = event["payload"]["rate_limits"]
+    windows = [rate_limits.get("primary"), rate_limits.get("secondary")]
+    remaining = [value for value in map(remaining_percent, windows) if value is not None]
+    reset_times = [
+        window.get("resets_at")
+        for window in windows
+        if isinstance(window, dict) and isinstance(window.get("resets_at"), (int, float))
+    ]
+    age_seconds = max(0, int(sampled_at - observed_at))
+    reset_elapsed = any(float(reset_at) <= sampled_at for reset_at in reset_times)
+    stale = age_seconds > max_age or reset_elapsed
+    limit_reached = rate_limits.get("rate_limit_reached_type") is not None
+    spend_control = bool(rate_limits.get("spend_control_reached"))
+
+    status = "ok"
+    if mode == "unavailable":
+        status = "auth_error"
+    elif mode != "chatgpt":
+        status = "not_chatgpt"
+    elif not remaining:
+        status = "invalid_snapshot"
+    elif stale:
+        status = "stale"
+    elif limit_reached or spend_control:
+        status = "exhausted"
+
+    record.update(
+        {
+            "status": status,
+            "schedulable": status == "ok",
+            "snapshot_at": event.get("timestamp"),
+            "snapshot_age_seconds": age_seconds,
+            "session_path": str(session_path),
+            "effective_remaining_percent": min(remaining) if remaining else None,
+            "rate_limits": rate_limits,
+        }
+    )
+    return record
+
+
+def parse_home(value: str) -> tuple[str, Path]:
+    profile, separator, raw_path = value.partition("=")
+    if not separator or not profile or not raw_path:
+        raise argparse.ArgumentTypeError("expected PROFILE=CODEX_HOME")
+    return profile, Path(raw_path).expanduser().resolve()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--home",
+        action="append",
+        required=True,
+        type=parse_home,
+        metavar="PROFILE=CODEX_HOME",
+        help="profile label and its Codex home; repeat for every app-server",
+    )
+    parser.add_argument("--codex", default="codex", help="Codex executable (default: codex)")
+    parser.add_argument(
+        "--max-age",
+        required=True,
+        type=int,
+        metavar="SECONDS",
+        help="maximum schedulable snapshot age",
+    )
+    args = parser.parse_args()
+    if args.max_age < 0:
+        parser.error("--max-age must be non-negative")
+
+    sampled_at = datetime.now(timezone.utc).timestamp()
+    for profile, codex_home in args.home:
+        print(
+            json.dumps(
+                sample_profile(profile, codex_home, args.codex, args.max_age, sampled_at),
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -87,7 +87,7 @@ def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
 
 def latest_rate_limits(
     sessions_dir: Path, not_before: float
-) -> tuple[dict[str, Any], Path] | None:
+) -> tuple[dict[str, Any], Path, bool] | None:
     session_files: list[tuple[float, Path]] = []
     try:
         for path in sessions_dir.rglob("*.jsonl"):
@@ -111,12 +111,12 @@ def latest_rate_limits(
             latest = candidate
 
     if latest is not None:
-        return latest[1], latest[2]
+        return latest[1], latest[2], True
 
     for _, path in session_files[older_start:]:
         candidate = latest_in_file(path)
         if candidate is not None:
-            return candidate[1], candidate[2]
+            return candidate[1], candidate[2], False
 
     return None
 
@@ -129,8 +129,9 @@ def login_mode(codex_home: Path, codex: str) -> str:
             [codex, "login", "status"],
             check=False,
             capture_output=True,
+            encoding="utf-8",
             env=environment,
-            text=True,
+            errors="replace",
             timeout=15,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -188,7 +189,7 @@ def sample_profile(
             record["status"] = "not_chatgpt"
         return record
 
-    event, session_path = snapshot
+    event, session_path, metadata_fresh = snapshot
     observed_at = parse_timestamp(event.get("timestamp"))
     if observed_at is None:
         record["status"] = "invalid_snapshot"
@@ -218,7 +219,12 @@ def sample_profile(
     clock_skew_seconds = observed_at - sampled_at
     age_seconds = max(0, int(-clock_skew_seconds))
     reset_elapsed = any(reset_at <= sampled_at for reset_at in reset_times)
-    stale = age_seconds > max_age or reset_elapsed or clock_skew_seconds > 60
+    stale = (
+        not metadata_fresh
+        or age_seconds > max_age
+        or reset_elapsed
+        or clock_skew_seconds > 60
+    )
     limit_reached = rate_limits.get("rate_limit_reached_type") is not None
     spend_control = bool(rate_limits.get("spend_control_reached"))
 

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -145,7 +145,7 @@ def login_mode(codex_home: Path, codex: str) -> str:
         for line in output.splitlines()
         if line.strip()
     ]
-    if "logged in using chatgpt" in status_lines:
+    if any(line.startswith("logged in using chatgpt") for line in status_lines):
         return "chatgpt"
     if any(line.startswith("logged in using an api key") for line in status_lines):
         return "other"

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -59,6 +59,7 @@ def reverse_lines(path: Path, chunk_size: int = 65536) -> Iterator[bytes]:
 
 
 def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
+    latest: tuple[float, dict[str, Any], Path] | None = None
     try:
         for raw_line in reverse_lines(path):
             try:
@@ -77,11 +78,11 @@ def latest_in_file(path: Path) -> tuple[float, dict[str, Any], Path] | None:
                 continue
 
             observed_at = parse_timestamp(event.get("timestamp"))
-            if observed_at is not None:
-                return observed_at, event, path
+            if observed_at is not None and (latest is None or observed_at > latest[0]):
+                latest = observed_at, event, path
     except OSError:
         return None
-    return None
+    return latest
 
 
 def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None:

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -145,9 +145,11 @@ def login_mode(codex_home: Path, codex: str) -> str:
         for line in output.splitlines()
         if line.strip()
     ]
-    if any(line.startswith("logged in using chatgpt") for line in status_lines):
+    if "logged in using chatgpt" in status_lines:
         return "chatgpt"
-    return "other" if status_lines else "unavailable"
+    if any(line.startswith("logged in using an api key") for line in status_lines):
+        return "other"
+    return "unavailable"
 
 
 def remaining_percent(window: Any) -> float | None:

--- a/skills/orchestrate-agents/scripts/read-codex-usage.py
+++ b/skills/orchestrate-agents/scripts/read-codex-usage.py
@@ -34,7 +34,7 @@ def latest_rate_limits(sessions_dir: Path) -> tuple[dict[str, Any], Path] | None
     latest: tuple[float, dict[str, Any], Path] | None = None
     for path in session_files:
         try:
-            with path.open(encoding="utf-8") as session:
+            with path.open(encoding="utf-8", errors="replace") as session:
                 for line in session:
                     try:
                         event = json.loads(line)
@@ -99,9 +99,10 @@ def sample_profile(
     codex_home: Path,
     codex: str,
     max_age: int,
-    sampled_at: float,
 ) -> dict[str, Any]:
     mode = login_mode(codex_home, codex)
+    snapshot = latest_rate_limits(codex_home / "sessions")
+    sampled_at = datetime.now(timezone.utc).timestamp()
     record: dict[str, Any] = {
         "profile": profile,
         "codex_home": str(codex_home),
@@ -116,7 +117,6 @@ def sample_profile(
         "rate_limits": None,
     }
 
-    snapshot = latest_rate_limits(codex_home / "sessions")
     if snapshot is None:
         record["status"] = "auth_error" if mode == "unavailable" else "no_snapshot"
         if mode == "other":
@@ -198,11 +198,10 @@ def main() -> int:
     if args.max_age < 0:
         parser.error("--max-age must be non-negative")
 
-    sampled_at = datetime.now(timezone.utc).timestamp()
     for profile, codex_home in args.home:
         print(
             json.dumps(
-                sample_profile(profile, codex_home, args.codex, args.max_age, sampled_at),
+                sample_profile(profile, codex_home, args.codex, args.max_age),
                 separators=(",", ":"),
                 sort_keys=True,
             )


### PR DESCRIPTION
## Summary

- sample the latest ChatGPT rate-limit snapshot from every managed `CODEX_HOME`
- reject stale, invalid, or exhausted profiles and expose normalized effective headroom
- route work using task-cost estimates, in-flight reservations, and reset-aware fallback

## Validation

- `python3 -m py_compile skills/orchestrate-agents/scripts/read-codex-usage.py`
- live ChatGPT-profile sampler smoke test
- skill validator
- target-only Prettier check
- `pnpm lint` reaches Prettier and reports the same two pre-existing `video-generation` Markdown formatting failures on clean current `main`