### PR TITLE
📝 docs(license): adopt MIT terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kros Dai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -63,5 +63,6 @@ Run `pnpm lint` to check the repository or `pnpm format` to apply formatting fix
 
 ## License
 
-This repository is licensed under the [MIT License](LICENSE). Third-party content retains
-its original license terms.
+Repository-owned content is licensed under the [MIT License](LICENSE). Bundled third-party
+content retains its original terms, including the
+[skill-creator license](.agents/skills/skill-creator/LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -63,4 +63,5 @@ Run `pnpm lint` to check the repository or `pnpm format` to apply formatting fix
 
 ## License
 
-Skills may have individual licenses. See each skill directory for details.
+This repository is licensed under the [MIT License](LICENSE). Third-party content retains
+its original license terms.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "engines": {
     "node": ">=24"
   },
+  "license": "MIT",
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && mise run autocorrect:fix",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "engines": {
     "node": ">=24"
   },
-  "license": "MIT",
+  "license": "MIT AND Apache-2.0",
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && mise run autocorrect:fix",


### PR DESCRIPTION
## Summary

- publish the canonical MIT License for repository-owned content
- declare MIT in package metadata and link it from the README
- preserve original terms for third-party content

## Validation

- pre-commit `lint-staged` hooks passed
- `pnpm exec prettier --check --ignore-unknown LICENSE README.md package.json`
- `git diff --check`
- full `pnpm lint` reaches two pre-existing Prettier warnings in untouched `skills/video-generation` Markdown files